### PR TITLE
jQuery UI class missing in table head

### DIFF
--- a/js/jquery.tablesorter.widgets.js
+++ b/js/jquery.tablesorter.widgets.js
@@ -28,7 +28,7 @@ $.tablesorter.addWidget({
 			$.each(c.headerList, function(){
 				$(this)
 				// using "ui-theme" class in case the user adds their own ui-icon using onRenderHeader
-				.addClass('ui-widget-header ui-corner-all')
+				.addClass('ui-widget-header ui-corner-all ui-state-default')
 				.append('<span class="ui-icon"/>')
 				.wrapInner('<div class="inner"/>')
 				.hover(function(){


### PR DESCRIPTION
The `ui-state-default` class for the table head columns is missing. Since the table head columns are getting `ui-state-hover` and `ui-state-active` they need the default-class too. Otherwise errors can occur with the border and the columns are shifting.
