### PR TITLE
Allow cssInfoBlock to be the first tbody element

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -158,8 +158,16 @@
 
 			function buildParserCache(table, $headers) {
 				if (table.tBodies.length === 0) { return; } // In the case of empty tables
-				var c = table.config, rows = table.tBodies[0].rows, ts = $.tablesorter,
-					list, l, i, h, m, ch, cl, p, parsersDebug = "";
+				var c = table.config, tBodies = table.tBodies, len = tBodies.length, rows, ts = $.tablesorter,
+					list, l, i, j, h, m, ch, cl, p, parsersDebug = "";
+
+				for (j = 0; j < len; j++) {
+					if ( !$(tBodies[j]).hasClass(c.cssInfoBlock) ) {
+						rows = tBodies[j].rows;
+						break;
+					}
+				}
+
 				if (rows[0]) {
 					list = [];
 					l = rows[0].cells.length;


### PR DESCRIPTION
Currently you can't have tbody with a cssInfoBlock class as the first tbody element. To fix this, I've added a simple loop to check for cssInfoBlock class rather than selecting the first tbody element.

I don't know about the additional plugins (I hope that this does not break any compatibility), but I guess a similar check should be added to those as well.
