### PR TITLE
Remove return false.

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -749,8 +749,6 @@
 							setHeadersCss($this[0], $headers, c.sortList);
 							multisort($this[0], c.sortList);
 							appendToTable($this[0]);
-							// stop normal event by returning false
-							return false;
 						}
 					});
 					if (c.cancelSelection) {


### PR DESCRIPTION
I assume this is around from before the change to mousedown and mouseup. Is there any particular reason for return false? It stops propigation and default action. Table sorting doesn't seem `sovereign` enough to assume this needs to be done.
