### PR TITLE
Support octets with a single digit in ipAddress parser

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -1026,7 +1026,7 @@
 	ts.addParser({
 		id: "ipAddress",
 		is: function(s) {
-			return (/^\d{2,3}[\.]\d{2,3}[\.]\d{2,3}[\.]\d{2,3}$/).test(s);
+			return (/^\d{1,3}[\.]\d{1,3}[\.]\d{1,3}[\.]\d{1,3}$/).test(s);
 		},
 		format: function(s, table) {
 			var i, item, a = s.split("."),
@@ -1034,7 +1034,9 @@
 			l = a.length;
 			for (i = 0; i < l; i++) {
 				item = a[i];
-				if (item.length === 2) {
+				if (item.length === 1) {
+					r += "00" + item;
+				} else if (item.length === 2) {
 					r += "0" + item;
 				} else {
 					r += item;


### PR DESCRIPTION
I just discovered that the IP address parsing in tablesorter has been broken since before your fork (I'm still using 2.0.5 at the moment) -- it doesn't recognize IP addresses with single digit octets! This patch should fix the problem.
