### PR TITLE
Remove use of innerHTML in the getElementText method

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -83,11 +83,7 @@
 					if (config.supportsTextContent) {
 						text = node.textContent;
 					} else {
-						if (node.childNodes[0] && node.childNodes[0].hasChildNodes()) {
-							text = node.childNodes[0].innerHTML;
-						} else {
-							text = node.innerHTML;
-						}
+						text = $(node).text();
 					}
 				} else {
 					if (typeof(te) === "function") {


### PR DESCRIPTION
Using innerHTML does an entity conversion of things like &nbsp;. This keeps functions like the digit format method from properly trimming white space. $.text() is a tiny bit slower but provides nicer results.
