### PR TITLE
Support two digit year formatted dates.

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -1092,11 +1092,11 @@
 			}
 			s = s.replace(/\s+/g," ").replace(/[\-|\.|\,]/g, "/");
 			if (format === "mmddyyyy") {
-				s = s.replace(/(\d{1,2})[\/\s](\d{1,2})[\/\s](\d{4})/, "$3/$1/$2");
+				s = s.replace(/(\d{1,2})[\/\s](\d{1,2})[\/\s](\d{2,4})/, "$3/$1/$2");
 			} else if (format === "ddmmyyyy") {
-				s = s.replace(/(\d{1,2})[\/\s](\d{1,2})[\/\s](\d{4})/, "$3/$2/$1");
+				s = s.replace(/(\d{1,2})[\/\s](\d{1,2})[\/\s](\d{2,4})/, "$3/$2/$1");
 			} else if (format === "yyyymmdd") {
-				s = s.replace(/(\d{4})[\/\s](\d{1,2})[\/\s](\d{1,2})/, "$1/$2/$3");
+				s = s.replace(/(\d{2,4})[\/\s](\d{1,2})[\/\s](\d{1,2})/, "$1/$2/$3");
 			}
 			return ts.formatFloat( (new Date(s).getTime() || ''), table);
 		},


### PR DESCRIPTION
I think tablesorter can support two digit year formatted dates with this change. Note that my change uses {2,4} which includes 3. I'm not so worried about about this as dates of this format would not have matched the `is` function. If someone is mixing in dates with three digits, their sorting would be stuffed anyway.

Are there other risks I'm not seeing?
