### PR TITLE
Update addons/pager/jquery.tablesorter.pager.js

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -138,6 +138,8 @@
 						$b.append('<tr class="pagerSavedHeightSpacer remove-me" style="height:' + d + 'px;"></tr>');
 					}
 				}
+			} else {
+				changeHeight(table, c);
 			}
 		},
 


### PR DESCRIPTION
Fixed issue where the fixed height is not being set on initial page load, only after a filter has been applied or the row count changes dynamically.
