### PR TITLE
Removing eval() for performance, usage was also causing variable collision in some minifiers

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -407,7 +407,7 @@
 									f.eq(j).addClass(css[list[i][1]]);
 									// add sorted class to footer, if it exists
 									if ($t.length) {
-										$t.filter('[data-column="' + list[i][0] + '"]').eq(j).addClass(css[list[i][1]]); 
+										$t.filter('[data-column="' + list[i][0] + '"]').eq(j).addClass(css[list[i][1]]);
 									}
 								}
 							}
@@ -455,42 +455,34 @@
 				sortTime, i, j, k, c, cache, lc, s, e, order, orgOrderCol;
 				if (tc.debug) { sortTime = new Date(); }
 				for (k = 0; k < bl; k++) {
-					dynamicExp = "sortWrapper = function(a,b) {";
 					cache = tc.cache[k];
 					lc = cache.normalized.length;
-					for (i = 0; i < l; i++) {
-						c = sortList[i][0];
-						order = sortList[i][1];
-						// fallback to natural sort since it is more robust
-						s = /n/i.test(getCachedSortType(tc.parsers, c)) ? "Numeric" : "Text";
-						s += order === 0 ? "" : "Desc";
-						e = "e" + i;
-						// get max column value (ignore sign)
-						if (/Numeric/.test(s) && tc.strings[c]) {
-							for (j = 0; j < lc; j++) {
-								col = Math.abs(parseFloat(cache.normalized[j][c]));
-								mx = Math.max( mx, isNaN(col) ? 0 : col );
+					cache.normalized.sort(function(a, b) {
+						for (i = 0; i < l; i++) {
+							c = sortList[i][0];
+							order = sortList[i][1];
+							// fallback to natural sort since it is more robust
+							s = /n/i.test(getCachedSortType(tc.parsers, c)) ? "Numeric" : "Text";
+							s += order === 0 ? "" : "Desc";
+							// get max column value (ignore sign)
+							if (/Numeric/.test(s) && tc.strings[c]) {
+								for (j = 0; j < lc; j++) {
+									col = Math.abs(parseFloat(cache.normalized[j][c]));
+									mx = Math.max(mx, isNaN(col) ? 0 : col);
+								}
+								// sort strings in numerical columns
+								if (typeof (tc.string[tc.strings[c]]) === 'boolean') {
+									dir = (order === 0 ? 1 : -1) * (tc.string[tc.strings[c]] ? -1 : 1);
+								} else {
+									dir = (tc.strings[c]) ? tc.string[tc.strings[c]] || 0 : 0;
+								}
 							}
-							// sort strings in numerical columns
-							if (typeof(tc.string[tc.strings[c]]) === 'boolean') {
-								dir = (order === 0 ? 1 : -1) * (tc.string[tc.strings[c]] ? -1 : 1);
-							} else {
-								dir = (tc.strings[c]) ? tc.string[tc.strings[c]] || 0 : 0;
-							}
+							var sort = $.tablesorter["sort" + s](table, a[c], b[c], c, mx, dir);
+							if (sort) { return sort; }
 						}
-						dynamicExp += "var " + e + " = $.tablesorter.sort" + s + "(table,a[" + c + "],b[" + c + "]," + c + "," + mx +  "," + dir + "); ";
-						dynamicExp += "if (" + e + ") { return " + e + "; } ";
-						dynamicExp += "else { ";
-					}
-					// if value is the same keep orignal order
-					orgOrderCol = (cache.normalized && cache.normalized[0]) ? cache.normalized[0].length - 1 : 0;
-					dynamicExp += "return a[" + orgOrderCol + "]-b[" + orgOrderCol + "];";
-					for (i=0; i < l; i++) {
-						dynamicExp += "}; ";
-					}
-					dynamicExp += "return 0; ";
-					dynamicExp += "}; ";
-					cache.normalized.sort(eval(dynamicExp)); // sort using eval expression
+						orgOrderCol = (cache.normalized && cache.normalized[0]) ? cache.normalized[0].length - 1 : 0;
+						return a[orgOrderCol] - b[orgOrderCol];
+					});
 				}
 				if (tc.debug) { benchmark("Sorting on " + sortList.toString() + " and dir " + order + " time", sortTime); }
 			}


### PR DESCRIPTION
The `eval()` inside `multisort()` was causing minifier variable collision with a few minifiers.  Since this `eval` isn't necessary it might as well be removed so the browser can also optimize the code path.  Allowing all modern browsers to be able to JIT here can result in quite a speed boost for large datasets, the more correlated the data (better branch prediction) the faster the speedup will be.

I'm mainly fixing this for the minification issue, but if we can improve performance at the same time, win-win.
