### PR TITLE
Ability to remove sorting on a column with a key modifier

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -968,6 +968,14 @@
 				</td>
 				<td><a href="example-option-sortreset-sortrestart.html">Example</a></td>
 			</tr>
+      
+      <tr id="sortResetKey">
+        <td>sortResetKey</td>
+        <td>String</td>
+        <td>"ctrlKey"</td>
+        <td>The key used to reset sorting on the entire table. Defaults to the control key. The other options are <code>"shiftKey"</code> or <code>"altKey"</code>. Reference: <a class="external" href="https://developer.mozilla.org/en/DOM/MouseEvent">https://developer.mozilla.org/en/DOM/MouseEvent</a></td>
+        <td></td>
+      </tr>
 
 			<tr id="sortrestart">
 				<td><span class="permalink">sortRestart</span></td>

--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -40,6 +40,7 @@
 				sortMultiSortKey : 'shiftKey', // key used to select additional columns
 				usNumberFormat   : true,       // false for German "1.234.567,89" or French "1 234 567,89"
 				delayInit        : false,      // if false, the parsed table contents will not update until the first sort
+        sortResetKey     : 'ctrlKey',  // key used to remove sorting on a column
 
 				// sort options
 				headers          : {},         // set sorter, string, empty, locked order, sortInitialOrder, filter, etc.
@@ -568,7 +569,7 @@
 							// $cell = $(this);
 							k = !e[c.sortMultiSortKey];
 							// get current column sort order
-							cell.count = (cell.count + 1) % (c.sortReset ? 3 : 2);
+							cell.count = e[c.sortResetKey] ? 2 : (cell.count + 1) % (c.sortReset ? 3 : 2);
 							// reset all sorts on non-current column - issue #30
 							if (c.sortRestart) {
 								i = cell;


### PR DESCRIPTION
It may be useful to use a key modifier rather than 3 clicks to remove the sorting on a column. The patch supplied adds this functionality.

Note: minified version not updated.
