### PR TITLE
Ability to sort tables with multiple tbodies

### DIFF
--- a/docs/example-meta-parsers.html
+++ b/docs/example-meta-parsers.html
@@ -101,7 +101,7 @@
 
 <div class="next-up">
 	<hr />
-	<a href="index.html">Back to documentation</a>
+	Next up: <a href="example-multibody.html">Sort between multiple tbodies, with inner rows remaining static. &rsaquo;&rsaquo;</a>
 </div>
 
 </div>

--- a/docs/example-multibody-within.html
+++ b/docs/example-multibody-within.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+ <meta charset="utf-8">
+	<title>jQuery plugin: Tablesorter 2.0 - Sort within multiple tbodies, whilst sorting the inner rows too</title>
+
+	<!-- jQuery -->
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+
+	<!-- Demo stuff -->
+	<link rel="stylesheet" href="css/jq.css">
+	<script src="js/chili/jquery.chili-2.2.js"></script>
+	<script src="js/chili/recipes.js"></script>
+	<script src="js/docs.js"></script>
+
+	<!-- Tablesorter: required -->
+	<link rel="stylesheet" href="../css/theme.blue.css">
+	<script src="../js/jquery.tablesorter.js"></script>
+
+	<!-- Tablesorter: widgets (optional) -->
+	<script src="../js/jquery.tablesorter.widgets.js"></script>
+
+	<script id="js">$(function(){
+  
+        $('table').tablesorter({
+            'theme' : 'blue',
+            'sortBodies' : true,
+            // Return the 'key row' from a tbody, used for sorting the
+            // entire body
+            'primaryRow' : function(body) {
+                return $(body).find('tr').eq(0);
+            }
+        });
+            
+});</script>
+</head>
+<body>
+<div id="banner">
+	<h1>table<em>sorter</em></h1>
+	<h2>Sort within multiple tbodies, whilst sorting the inner rows too</h2>
+	<h3>Flexible client-side table sorting</h3>
+	<a href="index.html">Back to documentation</a>
+</div>
+<div id="main">
+<h1>Demo</h1>
+<div id="demo">
+    <table class="tablesorter">
+        <thead>
+        <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Superhero Name</th>
+        </tr>
+        </thead>
+        <tbody>
+            <tr><td>Bruce</td><td>Wayne</td><td>Batman</td></tr>
+            <tr><td colspan="3">Batman is the superhero protector of Gotham City, a man dressed like a bat who fights against evil and strikes terror into the hearts of criminals everywhere. In his secret identity he is Bruce Wayne, billionaire industrialist and notorious playboy. Although he has no superhuman powers, he is one of the world's smartest men and greatest fighters. His physical prowess and technical ingenuity make him an incredibly dangerous opponent. He is also a founding member of the Justice League and the Outsiders.</td></tr>
+        </tbody>
+
+        <tbody>
+            <tr><td>Hal</td><td>Jordan</td><td>Green Latern</td></tr>
+            <tr><td colspan="3">Hal Jordan is the most well-known Green Lantern. He was the first earthman ever inducted into the Green Lantern Corps, and has been heralded as possibly the greatest Green Lantern of all time. Green Lantern is also a founding member of the Justice League of America.</td></tr>
+        </tbody>
+
+        <tbody>
+            <tr><td>Clark</td><td>Kent</td><td>Superman</td></tr>
+            <tr><td colspan="3">Superman, also known as the Man of Steel, is one of the most powerful superheroes in the DC Universe. His abilities include incredible super-strength, super-speed, invulnerability, freezing breath, flight, and heat-vision.</td></tr>
+        </tbody>
+
+        <tbody>
+            <tr><td>Charles</td><td>Xavier</td><td>Professor X</td></tr>
+            <tr><td colspan="3">Charles Francis Xavier was born in New York City to the wealthy Brian Xavier, a well-respected nuclear scientist, and Sharon Xavier. After Brian died in an accident, his science partner Kurt Marko comforts and marries the grieving Sharon. When Xavier's telepathic mutant powers emerge, he discovers Kurt cares only about his mother's money.</td></tr>
+        </tbody>
+    </table>
+</div>
+
+	<h1>Javascript</h1>
+	<div id="javascript">
+		<pre class="js"></pre>
+	</div>
+	<h1>HTML</h1>
+	<div id="html">
+		<pre class="html"></pre>
+	</div>
+
+<div class="next-up">
+	<hr />
+	<a href="index.html">Back to documentation</a>
+</div>
+
+</div>
+
+</body>
+</html>

--- a/docs/example-multibody.html
+++ b/docs/example-multibody.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+ <meta charset="utf-8">
+	<title>jQuery plugin: Tablesorter 2.0 - Sort between multiple tbodies, with inner rows remaining static</title>
+
+	<!-- jQuery -->
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+
+	<!-- Demo stuff -->
+	<link rel="stylesheet" href="css/jq.css">
+	<script src="js/chili/jquery.chili-2.2.js"></script>
+	<script src="js/chili/recipes.js"></script>
+	<script src="js/docs.js"></script>
+
+	<!-- Tablesorter: required -->
+	<link rel="stylesheet" href="../css/theme.blue.css">
+	<script src="../js/jquery.tablesorter.js"></script>
+
+	<!-- Tablesorter: widgets (optional) -->
+	<script src="../js/jquery.tablesorter.widgets.js"></script>
+
+	<script id="js">$(function(){
+  
+        $('table').tablesorter({
+            'theme' : 'blue',
+            'sortBodies' : true,
+            // Return the 'key row' from a tbody, used for sorting the
+            // entire body
+            'primaryRow' : function(body) {
+                return $(body).find('tr').eq(0);
+            }
+        });
+            
+});</script>
+</head>
+<body>
+<div id="banner">
+	<h1>table<em>sorter</em></h1>
+	<h2>Sort between multiple tbodies, with inner rows remaining static</h2>
+	<h3>Flexible client-side table sorting</h3>
+	<a href="index.html">Back to documentation</a>
+</div>
+<div id="main">
+<h1>Demo</h1>
+<div id="demo">
+    <table class="tablesorter">
+        <thead>
+        <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Superhero Name</th>
+        </tr>
+        </thead>
+        <tbody class="tablesorter-infoOnly">
+            <tr><td>Bruce</td><td>Wayne</td><td>Batman</td></tr>
+            <tr><td colspan="3">Batman is the superhero protector of Gotham City, a man dressed like a bat who fights against evil and strikes terror into the hearts of criminals everywhere. In his secret identity he is Bruce Wayne, billionaire industrialist and notorious playboy. Although he has no superhuman powers, he is one of the world's smartest men and greatest fighters. His physical prowess and technical ingenuity make him an incredibly dangerous opponent. He is also a founding member of the Justice League and the Outsiders.</td></tr>
+        </tbody>
+
+        <tbody class="tablesorter-infoOnly">
+            <tr><td>Hal</td><td>Jordan</td><td>Green Latern</td></tr>
+            <tr><td colspan="3">Hal Jordan is the most well-known Green Lantern. He was the first earthman ever inducted into the Green Lantern Corps, and has been heralded as possibly the greatest Green Lantern of all time. Green Lantern is also a founding member of the Justice League of America.</td></tr>
+        </tbody>
+
+        <tbody class="tablesorter-infoOnly">
+            <tr><td>Clark</td><td>Kent</td><td>Superman</td></tr>
+            <tr><td colspan="3">Superman, also known as the Man of Steel, is one of the most powerful superheroes in the DC Universe. His abilities include incredible super-strength, super-speed, invulnerability, freezing breath, flight, and heat-vision.</td></tr>
+        </tbody>
+
+        <tbody class="tablesorter-infoOnly">
+            <tr><td>Charles</td><td>Xavier</td><td>Professor X</td></tr>
+            <tr><td colspan="3">Charles Francis Xavier was born in New York City to the wealthy Brian Xavier, a well-respected nuclear scientist, and Sharon Xavier. After Brian died in an accident, his science partner Kurt Marko comforts and marries the grieving Sharon. When Xavier's telepathic mutant powers emerge, he discovers Kurt cares only about his mother's money.</td></tr>
+        </tbody>
+    </table>
+</div>
+
+	<h1>Javascript</h1>
+	<div id="javascript">
+		<pre class="js"></pre>
+	</div>
+	<h1>HTML</h1>
+	<div id="html">
+		<pre class="html"></pre>
+	</div>
+
+<div class="next-up">
+	<hr />
+	Next up: <a href="example-multibody-within.html">Sorting within multiple tbodies, whilst sorting the inner rows too. &rsaquo;&rsaquo;</a>
+</div>
+
+</div>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -353,6 +353,12 @@
 		<li><a href="example-meta-headers.html">Disable header using metadata</a></li>
 		<li><a href="example-meta-parsers.html">Setting column parser using metadata</a></li>
 	</ul>
+  
+  <h4>Sorting between multiple tbodies</h4>
+  <ul>
+    <li><a href="example-multibody.html">Sort between multiple tbodies, with inner rows remaining static.</li>
+    <li><a href="example-multibody-within.html">Sort within multiple tbodies, whilst sorting the inner rows too.</li>
+  </ul>
 	</div>
 	<br class="clear">
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
 	<!-- Pick a theme, load the plugin & initialize plugin -->
 	<link href="css/theme.default.css" rel="stylesheet">
-	<script src="js/jquery.tablesorter.min.js"></script>
+	<script src="js/jquery.tablesorter.js"></script>
 	<script src="js/jquery.tablesorter.widgets.js"></script>
 	<script>
 	$(function(){

--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -88,6 +88,10 @@
 				// advanced
 				debug            : false,
 
+				// sort bodies
+				sortBodies       : false, // flag to say whether to sort bodies with one another
+				primaryRow       : null, // function(tbody) - to get the primary row (i.e. the one to use when sorting bodies)
+
 				// Internal variables
 				headerList: [],
 				empties: {},
@@ -164,7 +168,7 @@
 
 			function buildParserCache(table) {
 				var c = table.config,
-					tb = $(table.tBodies).filter(':not(.' + c.cssInfoBlock + ')'),
+					tb = c.sortBodies ? $(table.tBodies) : $(table.tBodies).filter(':not(.' + c.cssInfoBlock + ')'),
 					rows, list, l, i, h, ch, p, parsersDebug = "";
 				if ( tb.length === 0) { return; } // In the case of empty tables
 				rows = tb[0].rows;
@@ -206,8 +210,9 @@
 				totalRows,
 				totalCells,
 				parsers = tc.parsers,
-				t, v, i, j, k, c, cols, cacheTime, colMax = [];
+				t, v, i, j, k, c, cols, $b, cacheTime, colMax = [];
 				tc.cache = {};
+				tc.bodyCache = {};
 				if (tc.debug) {
 					cacheTime = new Date();
 				}
@@ -215,16 +220,32 @@
 				if (tc.showProcessing) {
 					ts.isProcessing(table, true);
 				}
+				var getColsFromRow = function(row, totalCells) {
+					var cols = [];
+					for (j = 0; j < totalCells; ++j) {
+						t = getElementText(table, c[0].cells[j], j);
+						// allow parsing if the string is empty, previously parsing would change it to zero,
+						// in case the parser needs to extract data from the table cell attributes
+						v = parsers[j].format(t, table, c[0].cells[j], j);
+						cols.push(v);
+						if ((parsers[j].type || '').toLowerCase() === "numeric") {
+							colMax[j] = Math.max(Math.abs(v), colMax[j] || 0); // determine column max value (ignore sign)
+						}
+					}
+					return cols;
+				}
 				for (k = 0; k < b.length; k++) {
-					tc.cache[k] = { row: [], normalized: [] };
-					// ignore tbodies with class name from css.cssInfoBlock
-					if (!$(b[k]).hasClass(tc.cssInfoBlock)) {
+					// compute the cache if:
+					// we're not sorting by bodies AND we're ignoring this body
+					// OR
+					// we're sorting by bodies (the body being ignored will still need row data)
+					if ((!tc.sortBodies && !$(b[k]).hasClass(tc.cssInfoBlock)) || tc.sortBodies) {
+						tc.cache[k] = { row: [], normalized: [] };
 						totalRows = (b[k] && b[k].rows.length) || 0;
 						totalCells = (b[k].rows[0] && b[k].rows[0].cells.length) || 0;
 						for (i = 0; i < totalRows; ++i) {
 							/** Add the table data to main data array */
 							c = $(b[k].rows[i]);
-							cols = [];
 							// if this is a child row, add it to the last row's children and continue to the next row
 							if (c.hasClass(tc.cssChildRow)) {
 								tc.cache[k].row[tc.cache[k].row.length - 1] = tc.cache[k].row[tc.cache[k].row.length - 1].add(c);
@@ -232,22 +253,31 @@
 								continue;
 							}
 							tc.cache[k].row.push(c);
-							for (j = 0; j < totalCells; ++j) {
-								t = getElementText(table, c[0].cells[j], j);
-								// allow parsing if the string is empty, previously parsing would change it to zero,
-								// in case the parser needs to extract data from the table cell attributes
-								v = parsers[j].format(t, table, c[0].cells[j], j);
-								cols.push(v);
-								if ((parsers[j].type || '').toLowerCase() === "numeric") {
-									colMax[j] = Math.max(Math.abs(v), colMax[j] || 0); // determine column max value (ignore sign)
-								}
-							}
+
+							cols = getColsFromRow(c, totalCells);
 							cols.push(tc.cache[k].normalized.length); // add position for rowCache
 							tc.cache[k].normalized.push(cols);
 						}
 						tc.cache[k].colMax = colMax;
 					}
 				}
+				// if sorting bodies, create a separate body cache with similar layout to
+				// actual cache
+				if (tc.sortBodies) {
+					tc.bodyCache[0] = { body: [], normalized: [] };
+
+					for(k = 0; k < b.length; k++) {
+						$b = $(b[k]);
+						c = tc.primaryRow($b);
+						cols = getColsFromRow(c, c.cells ? c.cells.length : c.get(0).cells.length);
+						cols.push(tc.bodyCache[0].normalized.length);
+						tc.bodyCache[0].body.push($b);
+						tc.bodyCache[0].normalized.push(cols);
+					}
+
+					tc.bodyCache[0].colMax = colMax;
+				}
+
 				if (tc.showProcessing) {
 					ts.isProcessing(table); // remove processing icon
 				}
@@ -263,30 +293,46 @@
 				rows = [],
 				c2 = c.cache,
 				r, n, totalRows, checkCell, $bk, $tb,
-				i, j, k, l, pos, appendTime;
+				i, j, k, l, pos, appendTime, body;
 				if (c.debug) {
 					appendTime = new Date();
 				}
+				// rather than iterate over the bodies in numerical order, go through them in the
+				// order they should be in the table
 				for (k = 0; k < b.length; k++) {
-					$bk = $(b[k]);
-					if (!$bk.hasClass(c.cssInfoBlock)) {
+					r = c2[k].row;
+					n = c2[k].normalized;
+					totalRows = n.length;
+					checkCell = totalRows ? (n[0].length - 1) : 0;
+
+					// if sorting by bodies, our position etc. is changed by whatever is in the
+					// bodyCache, rather than the actual cache.
+					if(c.sortBodies) {
+						// get the body with the position of k (k == 0, means first body to show)
+						pos = c.bodyCache[0].normalized[k][checkCell];
+
+						// sort this body
+						$bk = $(c.bodyCache[0].body[pos]);
+						r = c2[pos].row;
+						n = c2[pos].normalized;
+					} else {
+						$bk = $(b[k])
+					}
+					if ((!c.sortBodies && !$(b[k]).hasClass(c.cssInfoBlock)) || c.sortBodies) {
 						// get tbody
-						$tb = ts.processTbody(table, $bk, true);
-						r = c2[k].row;
-						n = c2[k].normalized;
-						totalRows = n.length;
-						checkCell = totalRows ? (n[0].length - 1) : 0;
+						$tb = ts.processTbody(table, $bk, true, k);
 						for (i = 0; i < totalRows; i++) {
 							pos = n[i][checkCell];
 							rows.push(r[pos]);
 							// removeRows used by the pager plugin
-							if (!c.appender || !c.removeRows) {
+							if (!$bk.hasClass(c.cssInfoBlock) && (!c.appender || !c.removeRows)) {
 								l = r[pos].length;
 								for (j = 0; j < l; j++) {
 									$tb.append(r[pos][j]);
 								}
 							}
 						}
+
 						// restore tbody
 						ts.processTbody(table, $tb, false);
 					}
@@ -487,6 +533,11 @@
 						return a[orgOrderCol] - b[orgOrderCol];
 					});
 				}
+				// sort our body cache
+				if(tc.sortBodies) {
+					tc.bodyCache[0].normalized.sort(rowSorter);
+				}
+
 				if (tc.debug) { benchmark("Sorting on " + sortList.toString() + " and dir " + order + " time", sortTime); }
 			}
 
@@ -822,10 +873,15 @@
 
 			// detach tbody but save the position
 			// don't use tbody because there are portions that look for a tbody index (updateCell)
-			ts.processTbody = function(table, $tb, getIt){
-				var t, holdr;
+			ts.processTbody = function(table, $tb, getIt, pos){
+				var t, holdr, place;
 				if (getIt) {
-					$tb.before('<span class="tablesorter-savemyplace"/>');
+					if(typeof pos !== 'undefined') {
+						place = $(table).find('tbody').eq(pos);
+					} else {
+						place = $tb;
+					}
+					place.before('<span class="tablesorter-savemyplace"/>');
 					holdr = ($.fn.detach) ? $tb.detach() : $tb.remove();
 					return holdr;
 				}


### PR DESCRIPTION
Currently, tables with multiple tbodies can be sorted only within the tbody. That is, the rows inside each body are sorted relative to each other, but bodies remain relatively autonomous.

There's a use case where the user may wish to sort between bodies and either:
  a) sort the rows inside the body too
  b) leave the rows inside each body static, but have the bodies rearrange themselves

The patch supplied adds this functionality through the use of a bodyCache which works in a similar way to the current row cache.

The body cache is computed whenever sorting via bodies is enabled, and composes a cache identical to one "body" entry in the row cache, but spread across multiple bodies. Each "row" entry in the body cache is the normalized values of the "primary row" in each body.

A primary row is defined as a row that supplies the data for each column required for sorting that body.

I've attached some examples as to how to use the new functionality, and I'm fairly sure it remains backwards compatible with existing tablesorter configurations (all other examples still work)

Note: minified file not updated