### PR TITLE
WrapInner usage fix

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -367,7 +367,7 @@
 			function buildHeaders(table) {
 				var header_index = computeThIndexes(table), ch, $t,
 					h, i, t, lock, time, $tableHeaders, c = table.config;
-					c.headerList = [], c.headerContent = [];
+					c.headerList = []; c.headerContent = [];
 				if (c.debug) {
 					time = new Date();
 				}
@@ -382,7 +382,13 @@
 						h = c.onRenderTemplate.apply($t, [index, t]);
 						if (h && typeof h === 'string') { t = h; } // only change t if something is returned
 					}
-					this.innerHTML = '<div class="tablesorter-header-inner">' + t + '</div>'; // faster than wrapInner
+					$t.wrapInner(function() {
+						var $wrapper = $('<div class="tablesorter-header-inner"></div>');
+						var $content = $(this).children();
+						$wrapper
+							.append($content)
+							.appendTo(this);
+					});
 
 					if (c.onRenderHeader) { c.onRenderHeader.apply($t, [index]); }
 


### PR DESCRIPTION
Hello,

I was using your tablesorter plugin and suddenly faced an issue:
One of my columns has button widget in it's head (with sorter:false),
so after applying tablesorter plugin to the table, the data of the button is cleared and I can't disable/enable the button from that moment.

Here is my solution to this problem, but I'm not sure how it will co-work with headerTemplate. Generally it's a bad idea to recreate the content using innerHTML as some widgets can be already initialized there.
If you help me understand the cases where headerTemplate is used, I can complete the solution to be not a breaking change.
Thank you
