### PR TITLE
Styling disabled filter elements

### DIFF
--- a/css/theme.bootstrap.css
+++ b/css/theme.bootstrap.css
@@ -92,6 +92,9 @@ caption {
 	-o-transition: height 0.1s ease;
 	transition: height 0.1s ease;
 }
+.tablesorter-bootstrap .tablesorter-filter-row .tablesorter-filter.disabled {
+	background: #eee;
+}
 .tablesorter-bootstrap .tablesorter-filter-row td {
 	background: #eee;
 	line-height: normal;


### PR DESCRIPTION
When a filter element is disabled this state should be reflect through its style. Since the css classes are already there I've simply added a different background color. You can, of course, hide them by adding `display:block;` instead.
