### PR TITLE
Update index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>jQuery plugin: Tablesorter 2.0</title>
+<title>jQuery plugin: Tablesorter 2.9.1</title>
 
 <!-- jQuery -->
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
@@ -36,7 +36,7 @@
 <div id="main">
 	<p>
 		<strong>Author:</strong> Christian Bach<br>
-		<strong>Version:</strong> <a class="current-version" href="http://github.com/Mottie/tablesorter/downloads">2.1+</a> (forked from <a href="http://tablesorter.com/docs/">version 2.0.5</a>, <a href="https://github.com/Mottie/tablesorter/wiki/Change">changelog</a>)<br>
+		<strong>Version:</strong> <a class="current-version" href="#Ddownload">2.9.1</a> (forked from <a href="http://tablesorter.com/docs/">version 2.0.5</a>, <a href="https://github.com/Mottie/tablesorter/wiki/Change">changelog</a>)<br>
 		<strong>Licence:</strong>
 		Dual licensed under <a class="external" href="http://www.opensource.org/licenses/mit-license.php">MIT</a>
 		or <a class="external" href="http://www.opensource.org/licenses/gpl-license.php">GPL</a> licenses.


### PR DESCRIPTION
old download link (http://github.com/Mottie/tablesorter/downloads) no longer works
