### PR TITLE
skip ajax request on sort event if serverSideSorting is disabled

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -513,7 +513,10 @@
 							$.data(table, 'pagerUpdateTriggered', false);
 							return;
 						}
-						moveToPage(table, c, false);
+						//only run the server side sorting if it has been enabled
+						if (e.type === "filterEnd" || (e.type === "sortEnd" && tc.serverSideSorting)) {
+						  moveToPage(table, c, false);
+						}
 						updatePageDisplay(table, c, false);
 						fixHeight(table, c);
 					})


### PR DESCRIPTION
Hi,

I am using the Ajax Pager with serverSideFiltering but not serverSideSorting. When i click a sort button the ajax pager is requesting a fresh copy of the data on each sortEnd event even if serverSideSorting is disabled. As the filters / page haven't changed and i am not sorting on the server then the data would not have changed, thus the extra ajax data request is redundant. 

This patch will test if serverSideSorting is disabled and will not run the data ajax request on the sortEnd Event. 

Note, It will still run ajax request on the filterEnd event and if serverSideFiltering has been enabled.
