### PR TITLE
jQuery version comparison bug: parseFloat does not see 1.10 > 1.4

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -832,7 +832,7 @@
 					if (c.debug) { $.data( table, 'startoveralltimer', new Date()); }
 					// constants
 					c.supportsTextContent = $('<span>x</span>')[0].textContent === 'x';
-					c.supportsDataObject = parseFloat($.fn.jquery) >= 1.4;
+					c.supportsDataObject = (function(version) { version[0] = parseInt(version[0]) ; return (version[0] > 1) || (version[0] == 1 && parseInt(version[1]) >= 4); })($.fn.jquery.split("."));
 					// digit sort text location; keeping max+/- for backwards compatibility
 					c.string = { 'max': 1, 'min': -1, 'max+': 1, 'max-': -1, 'zero': 0, 'none': 0, 'null': 0, 'top': true, 'bottom': false };
 					// add table theme class only if there isn't already one there


### PR DESCRIPTION
The current way of comparing the jQuery version is buggy because `parseFloat("1.10") == 1.1` this disables data attributes for jQuery 1.10 (current stable).

I know the problem solves itself for jQuery 2, but it's still a very big issue for the still maintained 1.x branch.

It would also be very appreciated if the fix was backported to the current stable version of tablesorter.

Great plugin BTW! Kudos!
