### PR TITLE
show any ajax request errors to the user in the table

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -295,7 +295,8 @@
 					$.tablesorter.isProcessing(table, true); // show loading icon
 				}
 				$doc.bind('ajaxError.pager', function(e, xhr, settings, exception) {
-					if (url.match(settings.url)) {
+					//show the error message on the table
+					if (url === settings.url) {
 						renderAjax(null, table, c, xhr, exception);
 						$doc.unbind('ajaxError.pager');
 					}


### PR DESCRIPTION
The ajaxError event is testing the url matches the stored settings url using the [String.match](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match) function which expects a regular expression as it's parameter. Instead use the equality operator to test the strings match, thus allowing the ajax error response message to be shown on the table.
