### PR TITLE
add an ajaxCounter to the pager object so it can index each request and ...

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -29,6 +29,8 @@
 			ajaxObject: {
 				dataType: 'json'
 			},
+			
+			ajaxCounter: 0,
 
 			// process ajax so that the following information is returned:
 			// [ total_rows (number), rows (array of arrays), headers (array; optional) ]
@@ -353,8 +355,17 @@
 					renderAjax(null, table, p, xhr, exception);
 					$doc.unbind('ajaxError.pager');
 				});
+
+				var counter = ++p.ajaxCounter;
+
 				p.ajaxObject.url = url; // from the ajaxUrl option and modified by customAjaxUrl
-				p.ajaxObject.success = function(data) {
+				p.ajaxObject.success = function(data)
+				{
+					//	Refuse to process old ajax commands that were overwritten by new ones
+					if(counter != p.ajaxCounter){
+						return;
+					}
+					
 					renderAjax(data, table, p);
 					$doc.unbind('ajaxError.pager');
 					if (typeof p.oldAjaxSuccess === 'function') {


### PR DESCRIPTION
...refuse to process old requests and only process the last one, this is important because when you execute multiple requests, sometimes the old requests return AFTER the new request has returned, meaning you get a mixed up data, this will stop that, even though really it should cancel the ajax request, but once the server has it, I don't know how you can do that.
