### PR TITLE
Bootstrap 3's disabled filter widget input element styling

### DIFF
--- a/css/theme.bootstrap.css
+++ b/css/theme.bootstrap.css
@@ -82,8 +82,14 @@
 	transition: height 0.1s ease;
 }
 .tablesorter-bootstrap .tablesorter-filter-row .tablesorter-filter.disabled {
-	background: #eee;
+	background-color: #eee;
+	color: #555;
 	cursor: not-allowed;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
+	box-sizing: border-box;
+	transition: height 0.1s ease;
 }
 .tablesorter-bootstrap .tablesorter-filter-row td {
 	background: #efefef;


### PR DESCRIPTION
Hi @Mottie,

I just added a minor stylesheet enhancement for the Boostrap3 Theme. It changes the look of the disabled filter widget input element to look more like the original BS (as seen here http://getbootstrap.com/css/#forms-control-states ).

Cheers
Erik
