### PR TITLE
Add sortDisabled check to buildHeaders function (issue #541 fix)

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -446,7 +446,11 @@
 						h = c.onRenderTemplate.apply($t, [index, t]);
 						if (h && typeof h === 'string') { t = h; } // only change t if something is returned
 					}
-					$(this).html('<div class="' + ts.css.headerIn + '">' + t + '</div>'); // faster than wrapInner
+					
+					var sortDisabled = ts.getData( this, c.headers[index], 'sorter' ) === 'false';
+                    			if (!sortDisabled) {
+                        			$(this).html('<div class="' + ts.css.headerIn + '">' + t + '</div>'); // faster than wrapInner
+                    			}
 
 					if (c.onRenderHeader) { c.onRenderHeader.apply($t, [index]); }
 


### PR DESCRIPTION
When sorting is disabled for a table header it removes sorting but still brings some issues described in #541 ('click' bindings are gone).
