### PR TITLE
Support search delay on filter keyup

### DIFF
--- a/js/jquery.tablesorter.widgets.js
+++ b/js/jquery.tablesorter.widgets.js
@@ -765,7 +765,7 @@ ts.filter = {
 					return;
 			}
 			// true flag tells getFilters to skip newest timed input
-			ts.filter.searching( table, '', true );
+			ts.filter.searching( table, true, true );
 		});
 		c.$table.bind('filterReset', function(){
 			$el.val('');


### PR DESCRIPTION
It appears the delay that allowed the user to finish typing before submitting the filter request is broken - causing multiple AJAX requests when using server-side filtering.

I changed the filter parameter of filter.searching to true when calling it from the keyup event handler so that the submission will delay until typing is complete.
