### PR TITLE
"TypeError: parsers[j] is undefined" in tablesorter.js line 302

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -296,6 +296,12 @@
 							}
 							tc.cache[k].row.push(c);
 							for (j = 0; j < totalCells; ++j) {
+								if (typeof parsers[j] === 'undefined') {
+									if (tc.debug) {
+										log('No parser found for cell:', c[0].cells[j], 'does it have a header?');
+									}
+									continue;
+								}
 								t = getElementText(table, c[0].cells[j], j);
 								// allow parsing if the string is empty, previously parsing would change it to zero,
 								// in case the parser needs to extract data from the table cell attributes


### PR DESCRIPTION
If you have a table with more table rows than header rows, or use colspan in the table head then it will fail to find a parser, giving us a runtime error.

It'll say "TypeError: parsers[j] is undefined" in tablesorter.js line 302.

JSFiddle demonstrating the issue at: http://jsfiddle.net/antila/N8m8J/1/

This is a very minor issue since it usually means you're doing something wrong with the markup. 
