### PR TITLE
Fix table reset on pagination change

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -542,6 +542,7 @@
 			$.data(table, 'pagerLastPage', p.page);
 			$.data(table, 'pagerLastSize', p.size);
 			p.totalPages = Math.ceil( p.totalRows / p.size );
+			p.filteredPages = Math.ceil( p.filteredRows / p.size );
 			moveToPage(table, p);
 		},
 


### PR DESCRIPTION
We were getting an issue we were getting:
1) filtering to, say, 15 rows
2) moving to the last page
3) changing the pagination to more than 15 (or whatever)
4) no rows displayed

This seemed to fix it.
