### PR TITLE
Zebra highlighting for child rows with Bootstrap theme

### DIFF
--- a/css/theme.bootstrap.css
+++ b/css/theme.bootstrap.css
@@ -41,14 +41,18 @@
 }
 
 /* since bootstrap (table-striped) uses nth-child(), we just use this to add a zebra stripe color */
-.tablesorter-bootstrap > tbody > tr.odd > td {
+.tablesorter-bootstrap > tbody > tr.odd > td,
+.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.odd:hover ~ tr.tablesorter-hasChildRow.odd ~ .tablesorter-childRow.odd > td {
 	background-color: #f9f9f9;
 }
 .tablesorter-bootstrap > tbody > tr.odd:hover > td,
-.tablesorter-bootstrap > tbody > tr.even:hover > td {
+.tablesorter-bootstrap > tbody > tr.even:hover > td,
+.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.odd:hover ~ .tablesorter-childRow.odd > td,
+.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.even:hover ~ .tablesorter-childRow.even > td {
 	background-color: #f5f5f5;
 }
-.tablesorter-bootstrap > tbody > tr.even > td {
+.tablesorter-bootstrap > tbody > tr.even > td,
+.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.even:hover ~ tr.tablesorter-hasChildRow.even ~ .tablesorter-childRow.even > td {
 	background-color: #fff;
 }
 


### PR DESCRIPTION
Currently there is a problem with highlighting if a table have child rows, when using `rowspan` for example:

![childrows-hover](https://cloud.githubusercontent.com/assets/1911270/2600010/84afa1f0-baf3-11e3-9768-0b251acd9fb7.png)

See on the screen-shot the central row is hovered but its child rows (e.g. ALARM_WATER) is unhighlighted.
My solution might look a bit over-complicated but I could not come up with a better one with pure CSS.
