### PR TITLE
Added `read-components` compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,5 +3,6 @@
   "version": "2.15.13",
   "dependencies": {
     "jquery": ">=1.2.6"
-  }
+  },
+  "main": "js/jquery.tablesorter.js"
 }


### PR DESCRIPTION
https://github.com/paulmillr/read-components

> read-components was made for automatic builders like [Brunch](http://brunch.io).
> Automatic means you don’t need to specify bower files which will be built.
> Instead, read-components reads root `bower.json`, opens `bower.json` of
> all packages and their dependencies and auto-calculates concatenation order.
