### PR TITLE
Pager widget - slow table update when there are a large number of page number links

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -191,7 +191,6 @@
 						pg = Math.min( p.totalPages, p.filteredPages );
 						// Filter the options page number link array if it's larger than 'maxOptionSize'
 						// as large page set links will slow the browser on large dom inserts
-						var max_option_size = 20,
 						skip_set_size = Math.floor(pg / p.maxOptionSize),
 						large_collection = pg > p.maxOptionSize,
 						current_page = p.page + 1,


### PR DESCRIPTION
I am using the pager widget with server side filtering. When paged results where being returned the pager's 'goto' page links get updated. For large page sets the browser slows noticeable (sometimes even causing _unresponsive script_ errors) while inserting / replacing a large list of 'option' goto page links.

You can simulate the issue by replacing `pg = Math.min( p.totalPages, p.filteredPages );` with a large value, my page set was something like 25K `pg = 25000;` and then watch your browser slow down on render

I couldn't get a faster DOM insert / update mechanism working properly, see:
- http://stackoverflow.com/questions/3756839/best-way-to-insert-hundreds-of-dom-elements-into-the-page-dynamically-while-keep
- http://jsperf.com/innerhtml-vs-replacehtml

Instead I've created a representative sample into the set of "page options links", selecting a page based on a 'max_option_size' value, e.g. `select_every_x_records = 'total number of pages' / max_option_size`.

This might not be a great solution for everyone but it works for me. Perhaps this PR will save someone a few hours and possibly start a discussion re large page links sets slowing down the browser.
