### PR TITLE
Remove breakpoints sort

### DIFF
--- a/js/widgets/widget-columnSelector.js
+++ b/js/widgets/widget-columnSelector.js
@@ -120,7 +120,6 @@ tsColSel = ts.columnSelector = {
 		if (wo.columnSelector_mediaquery) {
 			// used by window resize function
 			colSel.lastIndex = -1;
-			wo.columnSelector_breakpoints.sort();
 			tsColSel.updateBreakpoints(c, wo);
 			c.$table
 				.off('updateAll' + namespace)


### PR DESCRIPTION
Sorting the breakpoints yields bad results if not all sizes are of the same length.
For instance, for the breakpoints [ '480px', '768px', '992px', '1200px', '1800px', '2200px' ], the first 3 sizes will be placed after the last 3, resulting in unexpected behaviour.
