### PR TITLE
Add AMD/browserify support

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -16,7 +16,15 @@
 */
 /*jshint browser:true, jquery:true, unused:false, expr: true */
 /*global console:false, alert:false */
-!(function($) {
+(function(factory) {
+	if (typeof define === 'function' && define.amd) {
+		define(['jquery'], factory);
+	} else if (typeof module === 'object' && typeof module.exports === 'object') {
+		module.exports = factory(require('jquery'));
+	} else {
+		factory(jQuery);
+	}
+}(function($) {
 	"use strict";
 	$.extend({
 		/*jshint supernew:true */
@@ -1940,4 +1948,5 @@
 		}
 	});
 
-})(jQuery);
+	return ts;
+}));

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"natural",
 		"jquery-plugin"
 	],
-	"main": "js/tablesorter.js",
+	"main": "js/jquery.tablesorter.js",
 	"files": [
 		"css/theme.default.css",
 		"js/jquery.tablesorter.js",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
 	"main": "js/tablesorter.js",
 	"files": [
 		"css/theme.default.css",
+		"js/jquery.tablesorter.js",
 		"js/jquery.tablesorter.min.js",
+		"js/jquery.tablesorter.widgets.js",
 		"js/jquery.tablesorter.widgets.min.js",
 		"addons/pager/"
 	],


### PR DESCRIPTION
This adds support for AMD loaders like requirejs, as well as browserify, so that a shim config isn't needed in either case. This is pretty standard boilerplate but there are examples for most environments at https://github.com/umdjs/umd

I fixed some problems in package.json that prevented the module from working with npm/browserify. The `main` field (which indicates the entry file when someone does `var tablesorter = require('tablesorter')`) was referencing a file that doesn't exist, so I changed it to include the non-minified files and have it reference `js/jquery.tablesorter.js` as `main`. The non-minified files are more useful for development/debugging, and people using these tools already have their own minification process for deployment.