### PR TITLE
Fix potential bug

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -250,7 +250,7 @@
 				};
 				while (j < len) {
 					rows = tb[j].rows;
-					if (rows[j]) {
+					if (rows.length) {
 						l = c.columns; // rows[j].cells.length;
 						for (i = 0; i < l; i++) {
 							h = c.$headers.filter('[data-column="' + i + '"]:last');


### PR DESCRIPTION
Fix check which can cause unresolving parsers in case that first tbody is empty and consequent tbodies have less rows than a number of tbody.
I'm not sure, anyone even encountered it in real life, but it is possible to create situation where it appears by adding some empty tbodies at the start of table.