### PR TITLE
glyphicon classes removed

### DIFF
--- a/docs/example-widget-bootstrap-theme.html
+++ b/docs/example-widget-bootstrap-theme.html
@@ -42,8 +42,8 @@
 		// icon class names
 		icons        : '', // add "icon-white" to make them white; this icon class is added to the <i> in the header
 		iconSortNone : 'bootstrap-icon-unsorted', // class name added to icon when column is not sorted
-		iconSortAsc  : 'icon-chevron-up glyphicon glyphicon-chevron-up', // class name added to icon when column has ascending sort
-		iconSortDesc : 'icon-chevron-down glyphicon glyphicon-chevron-down', // class name added to icon when column has descending sort
+		iconSortAsc  : 'icon-chevron-up', // class name added to icon when column has ascending sort
+		iconSortDesc : 'icon-chevron-down', // class name added to icon when column has descending sort
 		filterRow    : '', // filter row class
 		footerRow    : '',
 		footerCells  : '',


### PR DESCRIPTION
Leaving the glyphicon classes force a graphic error in the stickyHeader widget as shown here http://awesomescreenshot.com/0694lvfld1