### PR TITLE
Math: ignore using attr even if math_ignore is empty

### DIFF
--- a/js/widgets/widget-math.js
+++ b/js/widgets/widget-math.js
@@ -22,8 +22,9 @@
 				$row = $el.closest('tr'),
 				$cells = $row.children();
 			if (!$row.hasClass(wo.filter_filteredRow || 'filtered')) {
+				$cells = $cells.not('[' + dataAttrib + '=ignore]');
 				if (wo.math_ignore.length) {
-					$cells = $cells.not('[' + dataAttrib + '=ignore]').not('[data-column=' + wo.math_ignore.join('],[data-column=') + ']');
+					$cells = $cells.not('[data-column=' + wo.math_ignore.join('],[data-column=') + ']');
 				}
 				arry = $cells.not($el).map(function(){
 					$t = $(this);


### PR DESCRIPTION
I haven't really tested it but I don't think the fact that it should matter whether math_ignore is set for why cells should be ignored based on the ignore data attribute. In case I misunderstood something please add a comment.