### PR TITLE
Add tabindex attribute to do tabulation key works between filter inputs

### DIFF
--- a/js/jquery.tablesorter.widgets.js
+++ b/js/jquery.tablesorter.widgets.js
@@ -939,7 +939,7 @@ ts.filter = {
 				}
 				
 				// add tabindex
-				buildFilter.attr('tabindex', column );
+				buildFilter.attr('tabindex', 1 );
 			}
 		}
 	},

--- a/js/jquery.tablesorter.widgets.js
+++ b/js/jquery.tablesorter.widgets.js
@@ -937,6 +937,9 @@ ts.filter = {
 				if (disabled) {
 					buildFilter.attr('placeholder', '').addClass(tscss.filterDisabled)[0].disabled = true; // disabled!
 				}
+				
+				// add tabindex
+				buildFilter.attr('tabindex', column );
 			}
 		}
 	},


### PR DESCRIPTION
Hello,

I add tabindex attribute to do tabulation key works between filters inputs with new tablesorter-scroller-fixed-panel, added by The Sin (Issue 887).

Without tab index : 

http://jsfiddle.net/856bzzeL/208/

With tab index :

http://jsfiddle.net/856bzzeL/254/

Thanks