### PR TITLE
Fix alignment of fixed columns which bug when tbody first row has colspan columns

### DIFF
--- a/js/widgets/widget-scroller.js
+++ b/js/widgets/widget-scroller.js
@@ -296,7 +296,7 @@ ts.scroller = {
 	},
 
 	resize : function( c, wo ) {
-		var index, borderWidth, setWidth, $hCells, $bCells, $fCells, $headers, $this,
+		var index, borderWidth, setWidth, firstRowWithoutColSpan, $hCells, $bCells, $fCells, $headers, $this,
 			$table = c.$table,
 			$tableWrap = $table.parent(),
 			$hdr = wo.scroller_$header,
@@ -330,7 +330,8 @@ ts.scroller = {
 		$hdr.parent().add( $foot.parent() ).width( setWidth );
 
 		$hCells = $hdr.children( 'thead' ).children().children( 'th, td' ).filter( ':visible' );
-		$bCells = $table.children('tbody').eq( 0 ).children().eq( 0 ).children( 'th, td' ).filter( ':visible' );
+		firstRowWithoutColSpan = $table.children('tbody').eq( 0 ).children().not( ':has([colspan])' ).first().index();
+		$bCells = $table.children('tbody').eq( 0 ).children().eq( firstRowWithoutColSpan > 0 ? firstRowWithoutColSpan : 0 ).children( 'th, td' ).filter( ':visible' );
 		$fCells = $foot.children( 'tfoot' ).children().children( 'th, td' ).filter( ':visible' );
 
 		ts.scroller.setWidth( $hCells.add( $bCells ).add( $fCells ), '' );
@@ -514,7 +515,7 @@ ts.scroller = {
 		c.$table.parent().width( wo.scroller_$container.width() );
 
 		// scroller_fixedColumns
-		var index, tbodyIndex, rowIndex, $tbody, $adjCol, $fb, totalRows, widths,
+		var index, tbodyIndex, rowIndex, firstRowWithoutColSpan, firstRowWithoutColSpanIndex, $tbody, $adjCol, $fb, totalRows, widths,
 			$table = c.$table,
 			$wrapper = wo.scroller_$container,
 
@@ -573,7 +574,9 @@ ts.scroller = {
 		$fixedColumn.find( '.' + tscss.scrollerTable )
 			.height( $table.parent().height() - scrollBarWidth + borderBottomWidth );
 
-		// update fixed column tbody content, set row height & set cell widths for first row
+		// update fixed column tbody content, set row height & set cell widths for first row without colspan
+		firstRowWithoutColSpan = $table.children('tbody').eq( 0 ).children().not( ':has([colspan])' ).first().index();
+		firstRowWithoutColSpanIndex = firstRowWithoutColSpan > 0 ? firstRowWithoutColSpan : 0;
 		for ( tbodyIndex = 0; tbodyIndex < c.$tbodies.length; tbodyIndex++ ) {
 			$tbody = $mainTbodies.eq( tbodyIndex );
 			if ( $tbody.length ) {
@@ -589,7 +592,7 @@ ts.scroller = {
 					// set row height
 					$adjCol.children().eq( 0 ).height( $rows.eq( rowIndex ).outerHeight() - ( tsScroller.isFirefox ? borderBottomWidth * 2 : 0 ) );
 					// still need to adjust tbody cell widths ( the previous row may now be filtered )
-					if ( rowIndex === 0 ) {
+					if ( rowIndex === firstRowWithoutColSpanIndex ) {
 						tsScroller.setWidth( $adjCol.children().eq( 0 ), widths[ 0 ] );
 					}
 					$fb.append( $adjCol );


### PR DESCRIPTION
Hello,

I discovered a bug with fixed columns which appears when tbody first row contains colspan columns.

To view issue, go to demo here http://jsfiddle.net/856bzzeL/328/ and expanded well the screen in width and you can see this :

![capture](https://cloud.githubusercontent.com/assets/3995851/7744395/2c0c07aa-ffa3-11e4-8e48-e9d67d1631f5.png)

The problem appears because in widget scroller javascript, the width of columns of fixed colums is already set on first row :

```
				// still need to adjust tbody cell widths ( the previous row may now be filtered )
					if ( rowIndex === 0 ) {
						tsScroller.setWidth( $adjCol.children().eq( 0 ), widths[ 0 ] );
					}
```

I added a fix to set width on first row which no contains colspan. If all contains colspan, the width is added on first row like currently.

This fix, fix alignment issue. You can see a demo here with the fix : http://jsfiddle.net/856bzzeL/329/

![capture2](https://cloud.githubusercontent.com/assets/3995851/7744499/1c757a32-ffa4-11e4-8bcf-420b5c0f29d9.png)

Its works well with all browser : Firefox, Chrome, Internet Explorer

Can you integrate it in table sorter widget code?

Thanks