### PR TITLE
Fix sorting arrows on bootstrap3 theme.

### DIFF
--- a/css/theme.bootstrap.css
+++ b/css/theme.bootstrap.css
@@ -25,18 +25,26 @@
 	padding: 4px 18px 4px 4px;
 }
 
-/* bootstrap uses <i> for icons */
-.tablesorter-bootstrap .tablesorter-header i.tablesorter-icon {
-	font-size: 11px;
-	position: absolute;
-	right: 2px;
-	top: 50%;
-	margin-top: -7px; /* half the icon height; older IE doesn't like this */
-	width: 14px;
-	height: 14px;
-	background-repeat: no-repeat;
-	line-height: 14px;
-	display: inline-block;
+.tablesorter-bootstrap thead .headerSortUp,
+.tablesorter-bootstrap thead .tablesorter-headerSortUp,
+.tablesorter-bootstrap thead .tablesorter-headerAsc,
+.tablesorter-bootstrap thead .headerSortDown,
+.tablesorter-bootstrap thead .tablesorter-headerSortDown,
+.tablesorter-bootstrap thead .tablesorter-headerDesc {
+    background-repeat: no-repeat;
+    background-position-x: 100%;
+    background-position-y: 50%;
+	border-bottom: #000 2px solid;
+}
+.tablesorter-bootstrap thead .headerSortUp,
+.tablesorter-bootstrap thead .tablesorter-headerSortUp,
+.tablesorter-bootstrap thead .tablesorter-headerAsc {
+	background-image: url(data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjI8Bya2wnINUMopZAQA7);
+}
+.tablesorter-bootstrap thead .headerSortDown,
+.tablesorter-bootstrap thead .tablesorter-headerSortDown,
+.tablesorter-bootstrap thead .tablesorter-headerDesc {
+	background-image: url(data:image/gif;base64,R0lGODlhFQAEAIAAACMtMP///yH5BAEAAAEALAAAAAAVAAQAAAINjB+gC+jP2ptn0WskLQA7);
 }
 
 /* black unsorted icon */


### PR DESCRIPTION
Bootstrap 3 doesn't use `<i>` for icons. I changed the theme to
add sorting arrows similar to what's on the default theme. See
screenshot attached in this PR for an example. Tested on Bootstrap v3.3.4.

![2015-06-09-121051_654x83_scrot](https://cloud.githubusercontent.com/assets/59292/8062958/98cf8a86-0ea0-11e5-8a02-fd9a08a321da.png)
