### PR TITLE
Fixed IE11 crash when sort.

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -1349,12 +1349,14 @@
 				var holdr;
 				if (getIt) {
 					table.isProcessing = true;
-					$tb.before('<span class="tablesorter-savemyplace"/>');
 					holdr = ($.fn.detach) ? $tb.detach() : $tb.remove();
 					return holdr;
 				}
-				holdr = $(table).find('span.tablesorter-savemyplace');
-				$tb.insertAfter( holdr );
+				if ($(table).find("thead").length > 0) {
+					$(table).find("thead").after($tb);
+				} else {
+					$(table).prepend($tb);
+				}
 				holdr.remove();
 				table.isProcessing = false;
 			};


### PR DESCRIPTION
Hello. This is a great plugin, thank you for making it.

When testing on IE11 we found a bug which caused some issues however.
IE11 would crash when the table was sorted (the whole of IE, sometimes even requiring a computer restart).
This didn't seem to be an issue in versions of IE before 11.

I tracked this down to
```
$tb.before('<span class="tablesorter-savemyplace"/>')
```
I then also replicated this with insertBefore without jQuery.

IE11 crashes when a span is inserted between <thead> and <tbody> tags.
To avoid this I've changed the code to no longer require doing this.

I'm afraid that I wasn't sure if it was possible to have a table without a <thead> tag so I have coded for tables with and without <thead>. If it's not possible to have a table without a <thead> tag this code could be simplified to simply:
$(table).find("thead").after($tb);

I hope you can accept this pull request so that other people don't run into this issue.

Kind regards and all the best,
Shanee Vanstone.