### PR TITLE
fix to filter for undefined col

### DIFF
--- a/js/jquery.tablesorter.widgets.js
+++ b/js/jquery.tablesorter.widgets.js
@@ -1040,7 +1040,7 @@
 				// get data from jQuery data, metadata, headers option or header class name
 				col = ts.getColumnData( table, c.headers, column );
 				disabled = ts.getData( $header[0], col, 'filter' ) === 'false' ||
-					ts.getData( $header[0], col, 'parser' ) === 'false';
+					ts.getData( $header[0], col, 'parser' ) === 'false' || !$header[0];
 
 				if ( makeSelect ) {
 					buildFilter = $( '<select>' ).appendTo( c.$filters.eq( column ) );


### PR DESCRIPTION
Hello,

First thank you for this project! Big fan and have been using for around 2 years.

I did find an issue, which I've oversimplified in the solution below and was hoping to get some feedback. Basically, if there is a 3 col table with only 2 header cols (ie. <th colspan="2">) and filters are enabled, it will print out an extra filter on the 3rd col, with no way to disable (at least that I can find). The sorter treats it as one column, and disables it for sorting (expected result). I would expect filters to be treated the same way as sorting (disabled), but around jquery.tablesorter.js:703 it looks like an extra col is pushed if there is a colspan > 1. So the issue is that the sorter sees two cols and the filter sees three. I've attached a screenshot below to show an example of the issue.

In the for loop in jquery.tablesorter.widgets.js:1033, the call to c.$headerIndexed[ column ] returns undefined (as there is no actual 3rd col), and therefore even if you specify sorter: false in the headers option, it will print anyway.

So anyway, I was wondering your thoughts on this issue. Obviously the solution I've shown below is very oversimplified, and I just wanted to start the discussion before I went and added config options etc. The idea here is that if we are trying to pull data on a col that doesn't exist, set the field to disabled by default.

I think the ultimate solution would maybe be to either:

Set the filter to disabled if $header is undefined, and allow a boolean config option (ignoreColSpan?) to override to the current behavior
Add another array to push colspans to around jquery.tablesorter.js:703 for later access?
If you have a better idea I would be happy to try to implement.

Please be gentle, this is my first pull request to a public project!

* EDIT: added this on a branch instead of master 

![tablesorter_extra_filter](https://cloud.githubusercontent.com/assets/8114580/10484842/7ddec44e-7255-11e5-8b9b-8e3b19e0934c.png)
