### PR TITLE
Fix scroller_barWidth issue on iOS

### DIFF
--- a/js/widgets/widget-scroller.js
+++ b/js/widgets/widget-scroller.js
@@ -202,10 +202,19 @@
 			wo.scroller_saved = [ 0, 0 ];
 			wo.scroller_isBusy = true;
 
-			// set scrollbar width & allow setting width to zero
-			wo.scroller_barSetWidth = wo.scroller_barWidth !== null ?
-				wo.scroller_barWidth :
-				( tsScroller.getBarWidth() || 15 );
+			// set scrollbar width to one of the following (1) explicitly set scroller_barWidth option,
+			// (2) detected scrollbar width or (3) fallback of 15px
+			if (wo.scroller_barWidth !== null)
+			    wo.scroller_barSetWidth = wo.scroller_barWidth;
+			else {
+			    var detectedWidth = tsScroller.getBarWidth();
+			    if (detectedWidth !== null){
+			        wo.scroller_barSetWidth = detectedWidth;
+			    }
+			    else {
+			        wo.scroller_barSetWidth = 15;
+			    }
+			}
 
 			maxHt = wo.scroller_height || 300;
 


### PR DESCRIPTION
This change fixes an issue where the last column header gets cut off on MobileSafari (possibly other mobile browsers?) when using the widget-scroller plugin. 

MobileSafari doesn't allocate horizontal space for the vertical scollbar of vertically-scrolling regions, so the `getBarWidth()` function correctly returns 0 on iOS. The previous expression of `(tsScroller.getBarWidth() || 15)` incorrectly evaluates that 0 as "falsy" and sets `scroller_barSetWidth` to 15, which cuts off the last column header. This change explicitly tests for a null result from `tsScroller.getBarWidth()` and only applies 15px in that case 

I also expanded that section of code a little bit and modified the comment to make it more clear what's going on