### PR TITLE
Update widget-filter.js

### DIFF
--- a/js/widgets/widget-filter.js
+++ b/js/widgets/widget-filter.js
@@ -1089,7 +1089,7 @@
 
 					// data.iFilter = case insensitive ( if wo.filter_ignoreCase is true ),
 					// data.filter = case sensitive
-					data.iFilter = wo.filter_ignoreCase ? ( data.filter || '' ).toLowerCase() : data.filter;
+					data.iFilter = wo.filter_ignoreCase ? ( '' + data.filter ).toLowerCase() : data.filter;
 					fxn = vars.functions[ columnIndex ];
 					filterMatched = null;
 					if ( fxn ) {


### PR DESCRIPTION
When performing a case insensitive search and the filter input is a number an error is thrown
 
When data.filter is type number there isn't a toLowerCase function.
performing '' + data.filter converts it to a string to make sure it is always a string.