### PR TITLE
Modified stickyHeaderWidget for better performance.

### DIFF
--- a/js/widgets/widget-stickyHeaders.js
+++ b/js/widgets/widget-stickyHeaders.js
@@ -43,12 +43,12 @@
 				}
 				wo.resize_flag = false;
 			};
-		checkSizes( false );
 		clearInterval(wo.resize_timer);
 		if (disable) {
 			wo.resize_flag = false;
 			return false;
 		}
+		checkSizes( false );
 		wo.resize_timer = setInterval(function() {
 			if (wo.resize_flag) { return; }
 			checkSizes();


### PR DESCRIPTION
I just noticed that the checkSizes function is called before the disabled check which leads to an unnecessary performance loss as the data isn't required when disabling the table.