### PR TITLE
Update widget-scroller.js opt no Vertical Scroll

### DIFF
--- a/js/widgets/widget-scroller.js
+++ b/js/widgets/widget-scroller.js
@@ -248,8 +248,14 @@
 				.wrap( '<div class="' + tscss.scrollerHeader + '" />' )
 				.find( '.' + tscss.header );
 
-			// use max-height, so the height resizes dynamically while filtering
-			$table.wrap( '<div class="' + tscss.scrollerTable + '" style="max-height:' + maxHt + 'px;" />' );
+			// if max-height is greater than 0 use max-height, so the height resizes dynamically while filtering
+			// else let the table not have a vertical scroll
+			if(maxHt > 0){
+				$table.wrap( '<div class="' + tscss.scrollerTable + '" style="max-height:' + maxHt + 'px;" />' );
+			}
+			else {
+				$table.wrap( '<div class="' + tscss.scrollerTable + '" />' );	
+			}
 			$tableWrap = $table.parent();
 
 			// make scroller header sortable


### PR DESCRIPTION
If the max-height is set to -1 for example, the the vertical scrollbar is not added because the div is not constrained with a max-height.
However if you set it to 0, javascript sees a 0 as an empty/default value and uses 300 back on this line: 
`maxHt = wo.scroller_height || 300;`

Believe this deals with #907 