### PR TITLE
add license identifiers.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,10 @@
     "dist/js/jquery.tablesorter.combined.js",
     "dist/css/theme.blue.min.css"
   ],
+  "license" : [
+    "MIT",
+    "GPL-2.0+"
+  ],
   "ignore": [
     "/node_modules",
     "/bower_components",


### PR DESCRIPTION
Hi,

According to webjars.org the bower.json need a license in order to create a webjar release of tablesorter.

Output from webjars.org:


> Failed! All attempts to determine a license have been exhausted. The bower.json did not contain a 
> spec-compliant license definition and the license could not be determined by trolling through the 
> GitHub repo. This problem will likely need to be resolved by working with the library maintainers
> directly.
