### PR TITLE
From bind to on

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -222,7 +222,7 @@
 					if ($out.length) {
 						$out[ ($out[0].nodeName === 'INPUT') ? 'val' : 'html' ](s);
 						// rebind startRow/page inputs
-						$out.find('.ts-startRow, .ts-page').unbind('change' + namespace).bind('change' + namespace, function(){
+						$out.find('.ts-startRow, .ts-page').off('change' + namespace).on('change' + namespace, function(){
 							var v = $(this).val(),
 							pg = $(this).hasClass('ts-startRow') ? Math.floor( v / sz ) + 1 : v;
 							c.$table.triggerHandler('pageSet' + namespace, [ pg ]);
@@ -385,7 +385,7 @@
 				pagerArrows( table, p );
 				if ( !p.removeRows ) {
 					hideRows(table, p);
-					$(table).bind('sortEnd filterEnd '.split(' ').join(table.config.namespace + 'pager '), function(){
+					$(table).on('sortEnd filterEnd '.split(' ').join(table.config.namespace + 'pager '), function(){
 						hideRows(table, p);
 					});
 				}
@@ -532,9 +532,9 @@
 					if (c.showProcessing) {
 						ts.isProcessing(table, true); // show loading icon
 					}
-					$doc.bind('ajaxError' + namespace, function(e, xhr, settings, exception) {
+					$doc.on('ajaxError' + namespace, function(e, xhr, settings, exception) {
 						renderAjax(null, table, p, xhr, settings, exception);
-						$doc.unbind('ajaxError' + namespace);
+						$doc.off('ajaxError' + namespace);
 					});
 
 					counter = ++p.ajaxCounter;
@@ -547,7 +547,7 @@
 							return;
 						}
 						renderAjax(data, table, p, jqxhr);
-						$doc.unbind('ajaxError' + namespace);
+						$doc.off('ajaxError' + namespace);
 						if (typeof p.oldAjaxSuccess === 'function') {
 							p.oldAjaxSuccess(data);
 						}
@@ -860,9 +860,9 @@
 				.hide()
 				// unbind
 				.find( ctrls )
-				.unbind( namespace );
+				.off( namespace );
 				c.appender = null; // remove pager appender function
-				c.$table.unbind( namespace );
+				c.$table.off( namespace );
 				if (ts.storage) {
 					ts.storage(table, p.storageKey, '');
 				}
@@ -953,9 +953,9 @@
 					p.regexFiltered = new RegExp(wo.filter_filteredRow || 'filtered');
 
 					$t
-					// .unbind( namespace ) adding in jQuery 1.4.3 ( I think )
-					.unbind( pagerEvents.split(' ').join(namespace + ' ').replace(/\s+/g, ' ') )
-					.bind('filterInit filterStart '.split(' ').join(namespace + ' '), function(e, filters) {
+					// .off( namespace ) adding in jQuery 1.4.3 ( I think )
+					.off( pagerEvents.split(' ').join(namespace + ' ').replace(/\s+/g, ' ') )
+					.on('filterInit filterStart '.split(' ').join(namespace + ' '), function(e, filters) {
 						p.currentFilters = $.isArray(filters) ? filters : c.$table.data('lastSearch');
 						// don't change page if filters are the same (pager updating, etc)
 						if (e.type === 'filterStart' && p.pageReset !== false && (c.lastCombinedFilter || '') !== (p.currentFilters || []).join('')) {
@@ -963,7 +963,7 @@
 						}
 					})
 					// update pager after filter widget completes
-					.bind('filterEnd sortEnd '.split(' ').join(namespace + ' '), function() {
+					.on('filterEnd sortEnd '.split(' ').join(namespace + ' '), function() {
 						p.currentFilters = c.$table.data('lastSearch');
 						if (p.initialized || p.initializing) {
 							if (c.delayInit && c.rowsCopy && c.rowsCopy.length === 0) {
@@ -975,19 +975,19 @@
 							ts.applyWidget( table );
 						}
 					})
-					.bind('disablePager' + namespace, function(e){
+					.on('disablePager' + namespace, function(e){
 						e.stopPropagation();
 						showAllRows(table, p);
 					})
-					.bind('enablePager' + namespace, function(e){
+					.on('enablePager' + namespace, function(e){
 						e.stopPropagation();
 						enablePager(table, p, true);
 					})
-					.bind('destroyPager' + namespace, function(e){
+					.on('destroyPager' + namespace, function(e){
 						e.stopPropagation();
 						destroyPager(table, p);
 					})
-					.bind('updateComplete' + namespace, function(e, table, triggered){
+					.on('updateComplete' + namespace, function(e, table, triggered){
 						e.stopPropagation();
 						// table can be unintentionally undefined in tablesorter v2.17.7 and earlier
 						// don't recalculate total rows/pages if using ajax
@@ -1006,13 +1006,13 @@
 						changeHeight(table, p);
 						updatePageDisplay(table, p, true);
 					})
-					.bind('pageSize refreshComplete '.split(' ').join(namespace + ' '), function(e, size){
+					.on('pageSize refreshComplete '.split(' ').join(namespace + ' '), function(e, size){
 						e.stopPropagation();
 						setPageSize(table, parsePageSize( p, size, 'get' ), p);
 						hideRows(table, p);
 						updatePageDisplay(table, p, false);
 					})
-					.bind('pageSet pagerUpdate '.split(' ').join(namespace + ' '), function(e, num){
+					.on('pageSet pagerUpdate '.split(' ').join(namespace + ' '), function(e, num){
 						e.stopPropagation();
 						// force pager refresh
 						if (e.type === 'pagerUpdate') {
@@ -1023,7 +1023,7 @@
 						moveToPage(table, p, true);
 						updatePageDisplay(table, p, false);
 					})
-					.bind('pageAndSize' + namespace, function(e, page, size){
+					.on('pageAndSize' + namespace, function(e, page, size){
 						e.stopPropagation();
 						p.page = (parseInt(page, 10) || 1) - 1;
 						setPageSize(table, parsePageSize( p, size, 'get' ), p);
@@ -1040,8 +1040,8 @@
 					}
 					pager.find(ctrls.join(','))
 					.attr('tabindex', 0)
-					.unbind('click' + namespace)
-					.bind('click' + namespace, function(e){
+					.off('click' + namespace)
+					.on('click' + namespace, function(e){
 						e.stopPropagation();
 						var i, $t = $(this), l = ctrls.length;
 						if ( !$t.hasClass(p.cssDisabled) ) {
@@ -1058,8 +1058,8 @@
 					p.$goto = pager.find(p.cssGoto);
 					if ( p.$goto.length ) {
 						p.$goto
-						.unbind('change' + namespace)
-						.bind('change' + namespace, function(){
+						.off('change' + namespace)
+						.on('change' + namespace, function(){
 							p.page = $(this).val() - 1;
 							moveToPage(table, p, true);
 							updatePageDisplay(table, p, false);
@@ -1072,7 +1072,7 @@
 					if ( p.$size.length ) {
 						// setting an option as selected appears to cause issues with initial page size
 						p.$size.find('option').removeAttr('selected');
-						p.$size.unbind('change' + namespace).bind('change' + namespace, function() {
+						p.$size.off('change' + namespace).on('change' + namespace, function() {
 							if ( !$(this).hasClass(p.cssDisabled) ) {
 								var size = $(this).val();
 								p.$size.val( size ); // in case there are more than one pagers

--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -319,8 +319,8 @@
 			// show processesing icon
 			if ( c.showProcessing ) {
 				$table
-				.unbind( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace )
-				.bind( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace, function( e ) {
+				.off( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace )
+				.on( 'sortBegin' + c.namespace + ' sortEnd' + c.namespace, function( e ) {
 					clearTimeout( c.timerProcessing );
 					ts.isProcessing( table );
 					if ( e.type === 'sortBegin' ) {
@@ -353,40 +353,40 @@
 					.join( namespace + ' ' );
 			// apply easy methods that trigger bound events
 			$table
-			.unbind( events.replace( ts.regex.spaces, ' ' ) )
-			.bind( 'sortReset' + namespace, function( e, callback ) {
+			.off( events.replace( ts.regex.spaces, ' ' ) )
+			.on( 'sortReset' + namespace, function( e, callback ) {
 				e.stopPropagation();
 				// using this.config to ensure functions are getting a non-cached version of the config
 				ts.sortReset( this.config, callback );
 			})
-			.bind( 'updateAll' + namespace, function( e, resort, callback ) {
+			.on( 'updateAll' + namespace, function( e, resort, callback ) {
 				e.stopPropagation();
 				ts.updateAll( this.config, resort, callback );
 			})
-			.bind( 'update' + namespace + ' updateRows' + namespace, function( e, resort, callback ) {
+			.on( 'update' + namespace + ' updateRows' + namespace, function( e, resort, callback ) {
 				e.stopPropagation();
 				ts.update( this.config, resort, callback );
 			})
-			.bind( 'updateHeaders' + namespace, function( e, callback ) {
+			.on( 'updateHeaders' + namespace, function( e, callback ) {
 				e.stopPropagation();
 				ts.updateHeaders( this.config, callback );
 			})
-			.bind( 'updateCell' + namespace, function( e, cell, resort, callback ) {
+			.on( 'updateCell' + namespace, function( e, cell, resort, callback ) {
 				e.stopPropagation();
 				ts.updateCell( this.config, cell, resort, callback );
 			})
-			.bind( 'addRows' + namespace, function( e, $row, resort, callback ) {
+			.on( 'addRows' + namespace, function( e, $row, resort, callback ) {
 				e.stopPropagation();
 				ts.addRows( this.config, $row, resort, callback );
 			})
-			.bind( 'updateComplete' + namespace, function() {
+			.on( 'updateComplete' + namespace, function() {
 				this.isUpdating = false;
 			})
-			.bind( 'sorton' + namespace, function( e, list, callback, init ) {
+			.on( 'sorton' + namespace, function( e, list, callback, init ) {
 				e.stopPropagation();
 				ts.sortOn( this.config, list, callback, init );
 			})
-			.bind( 'appendCache' + namespace, function( e, callback, init ) {
+			.on( 'appendCache' + namespace, function( e, callback, init ) {
 				e.stopPropagation();
 				ts.appendCache( this.config, init );
 				if ( $.isFunction( callback ) ) {
@@ -394,32 +394,32 @@
 				}
 			})
 			// $tbodies variable is used by the tbody sorting widget
-			.bind( 'updateCache' + namespace, function( e, callback, $tbodies ) {
+			.on( 'updateCache' + namespace, function( e, callback, $tbodies ) {
 				e.stopPropagation();
 				ts.updateCache( this.config, callback, $tbodies );
 			})
-			.bind( 'applyWidgetId' + namespace, function( e, id ) {
+			.on( 'applyWidgetId' + namespace, function( e, id ) {
 				e.stopPropagation();
 				ts.applyWidgetId( this, id );
 			})
-			.bind( 'applyWidgets' + namespace, function( e, init ) {
+			.on( 'applyWidgets' + namespace, function( e, init ) {
 				e.stopPropagation();
 				// apply widgets
 				ts.applyWidget( this, init );
 			})
-			.bind( 'refreshWidgets' + namespace, function( e, all, dontapply ) {
+			.on( 'refreshWidgets' + namespace, function( e, all, dontapply ) {
 				e.stopPropagation();
 				ts.refreshWidgets( this, all, dontapply );
 			})
-			.bind( 'removeWidget' + namespace, function( e, name, refreshing ) {
+			.on( 'removeWidget' + namespace, function( e, name, refreshing ) {
 				e.stopPropagation();
 				ts.removeWidget( this, name, refreshing );
 			})
-			.bind( 'destroy' + namespace, function( e, removeClasses, callback ) {
+			.on( 'destroy' + namespace, function( e, removeClasses, callback ) {
 				e.stopPropagation();
 				ts.destroy( this, removeClasses, callback );
 			})
-			.bind( 'resetToLoadState' + namespace, function( e ) {
+			.on( 'resetToLoadState' + namespace, function( e ) {
 				e.stopPropagation();
 				// remove all widgets
 				ts.removeWidget( this, true, false );
@@ -454,8 +454,8 @@
 			// http://stackoverflow.com/questions/5312849/jquery-find-self;
 			.find( c.selectorSort )
 			.add( $headers.filter( c.selectorSort ) )
-			.unbind( tmp )
-			.bind( tmp, function( e, external ) {
+			.off( tmp )
+			.on( tmp, function( e, external ) {
 				var $cell, cell, temp,
 					$target = $( e.target ),
 					// wrap event type in spaces, so the match doesn't trigger on inner words
@@ -510,7 +510,7 @@
 				// cancel selection
 				$headers
 					.attr( 'unselectable', 'on' )
-					.bind( 'selectstart', false )
+					.on( 'selectstart', false )
 					.css({
 						'user-select' : 'none',
 						'MozUserSelect' : 'none' // not needed for jQuery 1.8+
@@ -2429,7 +2429,7 @@
 			}
 			// remove widget added rows, just in case
 			$h.find( 'tr' ).not( $r ).remove();
-			// disable tablesorter - not using .unbind( namespace ) because namespacing was
+			// disable tablesorter - not using .off( namespace ) because namespacing was
 			// added in jQuery v1.4.3 - see http://api.jquery.com/event.namespace/
 			events = 'sortReset update updateRows updateAll updateHeaders updateCell addRows updateComplete sorton ' +
 				'appendCache updateCache applyWidgetId applyWidgets refreshWidgets removeWidget destroy mouseup mouseleave ' +
@@ -2437,7 +2437,7 @@
 				.join( c.namespace + ' ' );
 			$t
 				.removeData( 'tablesorter' )
-				.unbind( events.replace( ts.regex.spaces, ' ' ) );
+				.off( events.replace( ts.regex.spaces, ' ' ) );
 			c.$headers
 				.add( $f )
 				.removeClass( [ ts.css.header, c.cssHeader, c.cssAsc, c.cssDesc, ts.css.sortAsc, ts.css.sortDesc, ts.css.sortNone ].join( ' ' ) )
@@ -2446,7 +2446,7 @@
 				.attr( 'aria-disabled', 'true' );
 			$r
 				.find( c.selectorSort )
-				.unbind( ( 'mousedown mouseup keypress '.split( ' ' ).join( c.namespace + ' ' ) ).replace( ts.regex.spaces, ' ' ) );
+				.off( ( 'mousedown mouseup keypress '.split( ' ' ).join( c.namespace + ' ' ) ).replace( ts.regex.spaces, ' ' ) );
 			ts.restoreHeaders( table );
 			$t.toggleClass( ts.css.table + ' ' + c.tableClass + ' tablesorter-' + c.theme, removeClasses === false );
 			// clear flag in case the plugin is initialized again

--- a/js/widgets/widget-cssStickyHeaders.js
+++ b/js/widgets/widget-cssStickyHeaders.js
@@ -59,8 +59,8 @@
 			}
 
 			$win
-			.unbind( ('scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') )
-			.bind('scroll resize '.split(' ').join(namespace), function() {
+			.off( ('scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') )
+			.on('scroll resize '.split(' ').join(namespace), function() {
 				// make sure "wo" is current otherwise changes to widgetOptions
 				// are not dynamic (like the add caption button in the demo)
 				wo = c.widgetOptions;
@@ -127,8 +127,8 @@
 
 			});
 			$table
-				.unbind( ('filterEnd' + namespace).replace(/\s+/g, ' ') )
-				.bind('filterEnd' + namespace, function() {
+				.off( ('filterEnd' + namespace).replace(/\s+/g, ' ') )
+				.on('filterEnd' + namespace, function() {
 					if (wo.cssStickyHeaders_filteredToTop) {
 						// scroll top of table into view
 						window.scrollTo(0, $table.position().top);
@@ -139,9 +139,9 @@
 		remove: function(table, c, wo, refreshing) {
 			if (refreshing) { return; }
 			var namespace = c.namespace + 'cssstickyheader ';
-			$(window).unbind( ('scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') );
+			$(window).off( ('scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') );
 			c.$table
-				.unbind( ('filterEnd scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') )
+				.off( ('filterEnd scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') )
 				.add( c.$table.children('thead').children().children() )
 				.children('thead, caption').css({
 					'transform' : '',

--- a/js/widgets/widget-filter-formatter-html5.js
+++ b/js/widgets/widget-filter-formatter-html5.js
@@ -104,13 +104,13 @@
 				// add HTML5 number (spinner)
 				$cell
 					.append(t + '<input type="hidden" />')
-					.find('.toggle, .number').bind('change', function(){
+					.find('.toggle, .number').on('change', function(){
 						updateNumber();
 					})
 					.closest('thead').find('th[data-column=' + indx + ']')
 					.addClass('filter-parsed') // get exact numbers from column
 					// on reset
-					.closest('table').bind('filterReset', function(){
+					.closest('table').on('filterReset', function(){
 						if ($.isArray(o.compare)) {
 							$cell.add($shcell).find(compareSelect).val( o.compare[ o.selected || 0 ] );
 						}
@@ -126,13 +126,13 @@
 							updateNumber();
 						}, 0);
 					});
-				$input = $cell.find('input[type=hidden]').bind('change', function(){
+				$input = $cell.find('input[type=hidden]').on('change', function(){
 					$cell.find('.number').val( this.value );
 					updateNumber();
 				});
 
 				// update slider from hidden input, in case of saved filters
-				c.$table.bind('filterFomatterUpdate', function(){
+				c.$table.on('filterFomatterUpdate', function(){
 					var val = tsff.updateCompare($cell, $input, o)[0] || o.value;
 					$cell.find('.number').val( ((val || '') + '').replace(/[><=]/g, '') );
 					updateNumber(false, true);
@@ -142,17 +142,17 @@
 				if (o.compare) {
 					// add compare select
 					tsff.addCompare($cell, indx, o);
-					$cell.find(compareSelect).bind('change', function(){
+					$cell.find(compareSelect).on('change', function(){
 						updateNumber();
 					});
 				}
 
 				// has sticky headers?
-				c.$table.bind('stickyHeadersInit', function(){
+				c.$table.on('stickyHeadersInit', function(){
 					$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx).empty();
 					$shcell
 						.append(t)
-						.find('.toggle, .number').bind('change', function(){
+						.find('.toggle, .number').on('change', function(){
 							$cell.find('.number').val( $(this).val() );
 							updateNumber();
 						});
@@ -160,7 +160,7 @@
 					if (o.compare) {
 						// add compare select
 						tsff.addCompare($shcell, indx, o);
-						$shcell.find(compareSelect).bind('change', function(){
+						$shcell.find(compareSelect).on('change', function(){
 							$cell.find(compareSelect).val( $(this).val() );
 							updateNumber();
 						});
@@ -237,7 +237,7 @@
 					// add span to header for the current slider value
 					.find('.tablesorter-header-inner').append('<span class="curvalue" />');
 				// hidden filter update namespace trigger by filter widget
-				$input = $cell.find('input[type=hidden]').bind('change' + c.namespace + 'filter', function(){
+				$input = $cell.find('input[type=hidden]').on('change' + c.namespace + 'filter', function(){
 					/*jshint eqeqeq:false */
 					var v = this.value,
 						compare = ($.isArray(o.compare) ? $cell.find(compareSelect).val() || o.compare[ o.selected || 0] : o.compare) || '';
@@ -248,12 +248,12 @@
 					}
 				});
 
-				$cell.find('.range').bind('change', function(){
+				$cell.find('.range').on('change', function(){
 					updateRange( this.value );
 				});
 
 				// update spinner from hidden input, in case of saved filters
-				c.$table.bind('filterFomatterUpdate', function(){
+				c.$table.on('filterFomatterUpdate', function(){
 					var val = tsff.updateCompare($cell, $input, o)[0];
 					$cell.find('.range').val( val );
 					updateRange(val, false, true);
@@ -263,17 +263,17 @@
 				if (o.compare) {
 					// add compare select
 					tsff.addCompare($cell, indx, o);
-					$cell.find(compareSelect).bind('change', function(){
+					$cell.find(compareSelect).on('change', function(){
 						updateRange();
 					});
 				}
 
 				// has sticky headers?
-				c.$table.bind('stickyHeadersInit', function(){
+				c.$table.on('stickyHeadersInit', function(){
 					$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx).empty();
 					$shcell
 						.html('<input class="range" type="range" min="' + o.min + '" max="' + o.max + '" value="' + o.value + '" />')
-						.find('.range').bind('change', function(){
+						.find('.range').on('change', function(){
 							updateRange( $shcell.find('.range').val() );
 						});
 					updateRange();
@@ -281,7 +281,7 @@
 					if (o.compare) {
 						// add compare select
 						tsff.addCompare($shcell, indx, o);
-						$shcell.find(compareSelect).bind('change', function(){
+						$shcell.find(compareSelect).on('change', function(){
 							$cell.find(compareSelect).val( $(this).val() );
 							updateRange();
 						});
@@ -290,7 +290,7 @@
 				});
 
 				// on reset
-				$cell.closest('table').bind('filterReset', function(){
+				$cell.closest('table').on('filterReset', function(){
 					if ($.isArray(o.compare)) {
 						$cell.add($shcell).find(compareSelect).val( o.compare[ o.selected || 0 ] );
 					}
@@ -378,23 +378,23 @@
 					$cell.closest('thead').find('th[data-column=' + indx + ']').find('.tablesorter-header-inner').append('<span class="curcolor" />');
 				}
 
-				$cell.find('.toggle, .colorpicker').bind('change', function(){
+				$cell.find('.toggle, .colorpicker').on('change', function(){
 					updateColor( $cell.find('.colorpicker').val() );
 				});
 
 				// hidden filter update namespace trigger by filter widget
-				$input = $cell.find('input[type=hidden]').bind('change' + c.namespace + 'filter', function(){
+				$input = $cell.find('input[type=hidden]').on('change' + c.namespace + 'filter', function(){
 					updateColor( this.value );
 				});
 
 				// update slider from hidden input, in case of saved filters
-				c.$table.bind('filterFomatterUpdate', function(){
+				c.$table.on('filterFomatterUpdate', function(){
 					updateColor( $input.val(), true );
 					ts.filter.formatterUpdated($cell, indx);
 				});
 
 				// on reset
-				$cell.closest('table').bind('filterReset', function(){
+				$cell.closest('table').on('filterReset', function(){
 					// just turn off the colorpicker
 					if (o.addToggle) {
 						$cell.find('.toggle')[0].checked = false;
@@ -408,11 +408,11 @@
 				});
 
 				// has sticky headers?
-				c.$table.bind('stickyHeadersInit', function(){
+				c.$table.on('stickyHeadersInit', function(){
 					$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx);
 					$shcell
 						.html(t)
-						.find('.toggle, .colorpicker').bind('change', function(){
+						.find('.toggle, .colorpicker').on('change', function(){
 							updateColor( $shcell.find('.colorpicker').val() );
 						});
 					updateColor( $shcell.find('.colorpicker').val() );

--- a/js/widgets/widget-filter-formatter-jui.js
+++ b/js/widgets/widget-filter-formatter-jui.js
@@ -72,7 +72,7 @@
 			$input = $('<input class="filter" type="hidden">')
 				.appendTo($cell)
 				// hidden filter update namespace trigger by filter widget
-				.bind('change' + c.namespace + 'filter', function(){
+				.on('change' + c.namespace + 'filter', function(){
 					updateSpinner({ value: this.value, delayed: false });
 				}),
 			$shcell = [],
@@ -121,7 +121,7 @@
 					'<label for="uispinnerbutton' + indx + '"></label></div>')
 					.appendTo($cell)
 					.find('.toggle')
-					.bind('change', function(){
+					.on('change', function(){
 						updateSpinner();
 					});
 			}
@@ -132,12 +132,12 @@
 				.val(o.value)
 				.appendTo($cell)
 				.spinner(o)
-				.bind('change keyup', function(){
+				.on('change keyup', function(){
 					updateSpinner();
 				});
 
 			// update spinner from hidden input, in case of saved filters
-			c.$table.bind('filterFomatterUpdate', function(){
+			c.$table.on('filterFomatterUpdate', function(){
 				var val = tsff.updateCompare($cell, $input, o)[0];
 				$cell.find('.spinner').val( val );
 				updateSpinner({ value: val }, true);
@@ -147,20 +147,20 @@
 			if (o.compare) {
 				// add compare select
 				tsff.addCompare($cell, indx, o);
-				$cell.find(compareSelect).bind('change', function(){
+				$cell.find(compareSelect).on('change', function(){
 					updateSpinner();
 				});
 			}
 
 			// has sticky headers?
-			c.$table.bind('stickyHeadersInit', function(){
+			c.$table.on('stickyHeadersInit', function(){
 				$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx).empty();
 				if (o.addToggle) {
 					$('<div class="button"><input id="stickyuispinnerbutton' + indx + '" type="checkbox" class="toggle" />' +
 						'<label for="stickyuispinnerbutton' + indx + '"></label></div>')
 						.appendTo($shcell)
 						.find('.toggle')
-						.bind('change', function(){
+						.on('change', function(){
 							$cell.find('.toggle')[0].checked = this.checked;
 							updateSpinner();
 						});
@@ -170,7 +170,7 @@
 					.val(o.value)
 					.appendTo($shcell)
 					.spinner(o)
-					.bind('change keyup', function(){
+					.on('change keyup', function(){
 						$cell.find('.spinner').val( this.value );
 						updateSpinner();
 					});
@@ -178,7 +178,7 @@
 				if (o.compare) {
 					// add compare select
 					tsff.addCompare($shcell, indx, o);
-					$shcell.find(compareSelect).bind('change', function(){
+					$shcell.find(compareSelect).on('change', function(){
 						$cell.find(compareSelect).val( $(this).val() );
 						updateSpinner();
 					});
@@ -187,7 +187,7 @@
 			});
 
 			// on reset
-			c.$table.bind('filterReset', function(){
+			c.$table.on('filterReset', function(){
 				if ($.isArray(o.compare)) {
 					$cell.add($shcell).find(compareSelect).val( o.compare[ o.selected || 0 ] );
 				}
@@ -230,7 +230,7 @@
 			$input = $('<input class="filter" type="hidden">')
 				.appendTo($cell)
 				// hidden filter update namespace trigger by filter widget
-				.bind('change' + c.namespace + 'filter', function(){
+				.on('change' + c.namespace + 'filter', function(){
 					updateSlider({ value: this.value });
 				}),
 			$shcell = [],
@@ -296,7 +296,7 @@
 				.slider(o);
 
 			// update slider from hidden input, in case of saved filters
-			c.$table.bind('filterFomatterUpdate', function(){
+			c.$table.on('filterFomatterUpdate', function(){
 				var val = tsff.updateCompare($cell, $input, o)[0];
 				$cell.find('.slider').slider('value', val );
 				updateSlider({ value: val }, false);
@@ -306,13 +306,13 @@
 			if (o.compare) {
 				// add compare select
 				tsff.addCompare($cell, indx, o);
-				$cell.find(compareSelect).bind('change', function(){
+				$cell.find(compareSelect).on('change', function(){
 					updateSlider({ value: $cell.find('.slider').slider('value') });
 				});
 			}
 
 			// on reset
-			c.$table.bind('filterReset', function(){
+			c.$table.on('filterReset', function(){
 				if ($.isArray(o.compare)) {
 					$cell.add($shcell).find(compareSelect).val( o.compare[ o.selected || 0 ] );
 				}
@@ -322,7 +322,7 @@
 			});
 
 			// has sticky headers?
-			c.$table.bind('stickyHeadersInit', function(){
+			c.$table.on('stickyHeadersInit', function(){
 				$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx).empty();
 
 				// add a jQuery UI slider!
@@ -330,7 +330,7 @@
 					.val(o.value)
 					.appendTo($shcell)
 					.slider(o)
-					.bind('change keyup', function(){
+					.on('change keyup', function(){
 						$cell.find('.slider').slider('value', this.value );
 						updateSlider();
 					});
@@ -338,7 +338,7 @@
 				if (o.compare) {
 					// add compare select
 					tsff.addCompare($shcell, indx, o);
-					$shcell.find(compareSelect).bind('change', function(){
+					$shcell.find(compareSelect).on('change', function(){
 						$cell.find(compareSelect).val( $(this).val() );
 						updateSlider();
 					});
@@ -369,7 +369,7 @@
 			$input = $('<input class="filter" type="hidden">')
 				.appendTo($cell)
 				// hidden filter update namespace trigger by filter widget
-				.bind('change' + c.namespace + 'filter', function(){
+				.on('change' + c.namespace + 'filter', function(){
 					getRange();
 				}),
 			$shcell = [],
@@ -443,13 +443,13 @@
 				.slider(o);
 
 			// update slider from hidden input, in case of saved filters
-			c.$table.bind('filterFomatterUpdate', function(){
+			c.$table.on('filterFomatterUpdate', function(){
 				getRange();
 				ts.filter.formatterUpdated($cell, indx);
 			});
 
 			// on reset
-			c.$table.bind('filterReset', function(){
+			c.$table.on('filterReset', function(){
 				$cell.find('.range').slider('values', o.values);
 				setTimeout(function(){
 					updateUiRange();
@@ -457,7 +457,7 @@
 			});
 
 			// has sticky headers?
-			c.$table.bind('stickyHeadersInit', function(){
+			c.$table.on('stickyHeadersInit', function(){
 				$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx).empty();
 
 				// add a jQuery UI slider!
@@ -465,7 +465,7 @@
 					.val(o.value)
 					.appendTo($shcell)
 					.slider(o)
-					.bind('change keyup', function(){
+					.on('change keyup', function(){
 						$cell.find('.range').val( this.value );
 						updateUiRange();
 					});
@@ -502,7 +502,7 @@
 			$input = $('<input class="dateCompare" type="hidden">')
 				.appendTo($cell)
 				// hidden filter update namespace trigger by filter widget
-				.bind('change' + c.namespace + 'filter', function(){
+				.on('change' + c.namespace + 'filter', function(){
 					var v = this.value;
 					if (v) {
 						o.onClose(v);
@@ -552,7 +552,7 @@
 			$date.datepicker(o);
 
 			// on reset
-			c.$table.bind('filterReset', function(){
+			c.$table.on('filterReset', function(){
 				if ($.isArray(o.compare)) {
 					$cell.add($shcell).find(compareSelect).val( o.compare[ o.selected || 0 ] );
 				}
@@ -563,7 +563,7 @@
 			});
 
 			// update date compare from hidden input, in case of saved filters
-			c.$table.bind('filterFomatterUpdate', function(){
+			c.$table.on('filterFomatterUpdate', function(){
 				var num, v = $input.val();
 				if (/\s+-\s+/.test(v)) {
 					// date range found; assume an exact match on one day
@@ -585,13 +585,13 @@
 			if (o.compare) {
 				// add compare select
 				tsff.addCompare($cell, indx, o);
-				$cell.find(compareSelect).bind('change', function(){
+				$cell.find(compareSelect).on('change', function(){
 					date1Compare();
 				});
 			}
 
 			// has sticky headers?
-			c.$table.bind('stickyHeadersInit', function(){
+			c.$table.on('stickyHeadersInit', function(){
 				$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx).empty();
 
 				// add a jQuery datepicker!
@@ -603,7 +603,7 @@
 				if (o.compare) {
 					// add compare select
 					tsff.addCompare($shcell, indx, o);
-					$shcell.find(compareSelect).bind('change', function(){
+					$shcell.find(compareSelect).on('change', function(){
 						$cell.find(compareSelect).val( $(this).val() );
 						date1Compare();
 					});
@@ -640,7 +640,7 @@
 			$input = $('<input class="dateRange" type="hidden">')
 				.appendTo($cell)
 				// hidden filter update namespace trigger by filter widget
-				.bind('change' + c.namespace + 'filter', function(){
+				.on('change' + c.namespace + 'filter', function(){
 					var v = this.value;
 					if (v.match(' - ')) {
 						v = v.split(' - ');
@@ -702,7 +702,7 @@
 			$cell.find('.dateTo').datepicker(o);
 
 			// update date compare from hidden input, in case of saved filters
-			c.$table.bind('filterFomatterUpdate', function(){
+			c.$table.on('filterFomatterUpdate', function(){
 				var val = $input.val() || '',
 					from = '',
 					to = '';
@@ -733,7 +733,7 @@
 			});
 
 			// has sticky headers?
-			c.$table.bind('stickyHeadersInit', function(){
+			c.$table.on('stickyHeadersInit', function(){
 				$shcell = c.widgetOptions.$sticky.find('.tablesorter-filter-row').children().eq(indx).empty();
 				$shcell.append(t);
 
@@ -747,7 +747,7 @@
 			});
 
 			// on reset
-			$cell.closest('table').bind('filterReset', function(){
+			$cell.closest('table').on('filterReset', function(){
 				$cell.add($shcell).find('.dateFrom').val('').datepicker('setDate', o.from || null );
 				$cell.add($shcell).find('.dateTo').val('').datepicker('setDate', o.to || null );
 				setTimeout(function(){

--- a/js/widgets/widget-filter-formatter-select2.js
+++ b/js/widgets/widget-filter-formatter-select2.js
@@ -33,7 +33,7 @@
 		$input = $('<input class="filter" type="hidden">')
 			.appendTo($cell)
 			// hidden filter update namespace trigger by filter widget
-			.bind('change' + c.namespace + 'filter', function(){
+			.on('change' + c.namespace + 'filter', function(){
 				var val = convertRegex(this.value);
 				c.$table.find('.select2col' + indx + ' .select2').select2('val', val);
 				updateSelect2();
@@ -107,7 +107,7 @@
 		// data options are already defined
 		if (!(o.ajax && !$.isEmptyObject(o.ajax)) && !o.data) {
 			updateOptions();
-			c.$table.bind('filterEnd', function(){
+			c.$table.on('filterEnd', function(){
 				updateOptions();
 				c.$table
 					.find('.select2col' + indx)
@@ -121,12 +121,12 @@
 			.val(o.value)
 			.appendTo($cell)
 			.select2(o)
-			.bind('change', function(){
+			.on('change', function(){
 				updateSelect2();
 			});
 
 		// update select2 from filter hidden input, in case of saved filters
-		c.$table.bind('filterFomatterUpdate', function() {
+		c.$table.on('filterFomatterUpdate', function() {
 			// value = '/(^x$|^y$)/' => 'x,y'
 			var val = convertRegex(c.$table.data('lastSearch')[indx] || '');
 			$cell = c.$table.find('.select2col' + indx);
@@ -136,14 +136,14 @@
 		});
 
 		// has sticky headers?
-		c.$table.bind('stickyHeadersInit', function(){
+		c.$table.on('stickyHeadersInit', function(){
 			var $shcell = c.widgetOptions.$sticky.find('.select2col' + indx).empty();
 			// add a select2!
 			$('<input class="select2 select2-' + indx + '" type="hidden">')
 				.val(o.value)
 				.appendTo($shcell)
 				.select2(o)
-				.bind('change', function(){
+				.on('change', function(){
 					c.$table.find('.select2col' + indx)
 						.find('.select2')
 						.select2('val', c.widgetOptions.$sticky.find('.select2col' + indx + ' .select2').select2('val') );
@@ -155,7 +155,7 @@
 		});
 
 		// on reset
-		c.$table.bind('filterReset', function(){
+		c.$table.on('filterReset', function(){
 			c.$table.find('.select2col' + indx).find('.select2').select2('val', o.value || '');
 			setTimeout(function(){
 				updateSelect2();

--- a/js/widgets/widget-filter.js
+++ b/js/widgets/widget-filter.js
@@ -74,7 +74,7 @@
 			$table
 				.removeClass( 'hasFilters' )
 				// add filter namespace to all BUT search
-				.unbind( events.replace( ts.regex.spaces, ' ' ) )
+				.off( events.replace( ts.regex.spaces, ' ' ) )
 				// remove the filter row even if refreshing, because the column might have been moved
 				.find( '.' + tscss.filterRow ).remove();
 			wo.filter_initialized = false;
@@ -411,7 +411,7 @@
 
 			txt = 'addRows updateCell update updateRows updateComplete appendCache filterReset ' +
 				'filterResetSaved filterEnd search '.split( ' ' ).join( c.namespace + 'filter ' );
-			c.$table.bind( txt, function( event, filter ) {
+			c.$table.on( txt, function( event, filter ) {
 				val = wo.filter_hideEmpty &&
 					$.isEmptyObject( c.cache ) &&
 					!( c.delayInit && event.type === 'appendCache' );
@@ -534,8 +534,8 @@
 			if ( c.showProcessing ) {
 				txt = 'filterStart filterEnd '.split( ' ' ).join( c.namespace + 'filter ' );
 				c.$table
-					.unbind( txt.replace( ts.regex.spaces, ' ' ) )
-					.bind( txt, function( event, columns ) {
+					.off( txt.replace( ts.regex.spaces, ' ' ) )
+					.on( txt, function( event, columns ) {
 					// only add processing to certain columns to all columns
 					$header = ( columns ) ?
 						c.$table
@@ -554,8 +554,8 @@
 			// add default values
 			txt = 'tablesorter-initialized pagerBeforeInitialized '.split( ' ' ).join( c.namespace + 'filter ' );
 			c.$table
-			.unbind( txt.replace( ts.regex.spaces, ' ' ) )
-			.bind( txt, function() {
+			.off( txt.replace( ts.regex.spaces, ' ' ) )
+			.on( txt, function() {
 				tsf.completeInit( this );
 			});
 			// if filter widget is added after pager has initialized; then set filter init flag
@@ -789,14 +789,14 @@
 			// use data attribute instead of jQuery data since the head is cloned without including
 			// the data/binding
 			.attr( 'data-lastSearchTime', new Date().getTime() )
-			.unbind( tmp.replace( ts.regex.spaces, ' ' ) )
-			.bind( 'keydown' + namespace, function( event ) {
+			.off( tmp.replace( ts.regex.spaces, ' ' ) )
+			.on( 'keydown' + namespace, function( event ) {
 				if ( event.which === tskeyCodes.escape && !table.config.widgetOptions.filter_resetOnEsc ) {
 					// prevent keypress event
 					return false;
 				}
 			})
-			.bind( 'keyup' + namespace, function( event ) {
+			.on( 'keyup' + namespace, function( event ) {
 				wo = table.config.widgetOptions; // make sure "wo" isn't cached
 				var column = parseInt( $( this ).attr( 'data-column' ), 10 ),
 					liveSearch = typeof wo.filter_liveSearch === 'boolean' ? wo.filter_liveSearch :
@@ -825,7 +825,7 @@
 				tsf.searching( table, true, true );
 			})
 			// include change for select - fixes #473
-			.bind( 'search change keypress input '.split( ' ' ).join( namespace + ' ' ), function( event ) {
+			.on( 'search change keypress input '.split( ' ' ).join( namespace + ' ' ), function( event ) {
 				// don't get cached data, in case data-column changes dynamically
 				var column = parseInt( $( this ).attr( 'data-column' ), 10 );
 				// don't allow 'change' event to process if the input value is the same - fixes #685
@@ -939,7 +939,7 @@
 			( $table || c.$table )
 				.find( '.' + tscss.filterRow )
 				.addClass( tscss.filterRowHide )
-				.bind( 'mouseenter mouseleave', function( e ) {
+				.on( 'mouseenter mouseleave', function( e ) {
 					// save event object - http://bugs.jquery.com/ticket/12140
 					var event = e,
 						$row = $( this );
@@ -957,7 +957,7 @@
 						}
 					}, 200 );
 				})
-				.find( 'input, select' ).bind( 'focus blur', function( e ) {
+				.find( 'input, select' ).on( 'focus blur', function( e ) {
 					var event = e,
 						$row = $( this ).closest( 'tr' );
 					clearTimeout( timer );

--- a/js/widgets/widget-grouping.js
+++ b/js/widgets/widget-grouping.js
@@ -138,7 +138,7 @@
 				$headers = c.$table.find( 'tr.group-header' ),
 				len = $headers.length;
 
-			$headers.bind( 'selectstart', false );
+			$headers.on( 'selectstart', false );
 			for ( index = 0; index < len; index++ ) {
 				$row = $headers.eq( index );
 				$rows = $row.nextUntil( 'tr.group-header' ).filter( ':visible' );

--- a/js/widgets/widget-lazyload.js
+++ b/js/widgets/widget-lazyload.js
@@ -137,10 +137,10 @@
 							timer = null;
 						}, _data.latency);
 					};
-				$(this).bind('scroll', handler).data(uid1, handler);
+				$(this).on('scroll', handler).data(uid1, handler);
 			},
 			teardown: function() {
-				$(this).unbind('scroll', $(this).data(uid1));
+				$(this).off('scroll', $(this).data(uid1));
 			}
 		};
 		special.scrollstop = {
@@ -162,10 +162,10 @@
 							dispatch.apply(_self, _args);
 						}, _data.latency);
 					};
-				$(this).bind('scroll', handler).data(uid2, handler);
+				$(this).on('scroll', handler).data(uid2, handler);
 			},
 			teardown: function() {
-				$(this).unbind('scroll', $(this).data(uid2));
+				$(this).off('scroll', $(this).data(uid2));
 			}
 		};
 	/*
@@ -246,7 +246,7 @@
 		settings.container === window) ? $window : $(settings.container);
 		/* Fire one scroll event per scroll. Not one scroll event per image. */
 		if (0 === settings.event.indexOf("scroll")) {
-			$container.bind(settings.event, function() {
+			$container.on(settings.event, function() {
 				return update();
 			});
 		}
@@ -268,7 +268,7 @@
 						settings.appear.call(self, elements_left, settings);
 					}
 					$("<img />")
-						.bind("load", function() {
+						.on("load", function() {
 							var original = $self.attr("data-" + settings.data_attribute);
 							$self.hide();
 							if ($self.is("img")) {
@@ -294,7 +294,7 @@
 			/* When wanted event is triggered load original image */
 			/* by triggering appear.                              */
 			if (0 !== settings.event.indexOf("scroll")) {
-				$self.bind(settings.event, function() {
+				$self.on(settings.event, function() {
 					if (!self.loaded) {
 						$self.trigger("appear");
 					}
@@ -302,13 +302,13 @@
 			}
 		});
 		/* Check if something appears when window is resized. */
-		$window.bind("resize", function() {
+		$window.on("resize", function() {
 			update();
 		});
 		/* With IOS5 force loading images when navigating with back button. */
 		/* Non optimal workaround. */
 		if ((/(?:iphone|ipod|ipad).*os 5/gi).test(navigator.appVersion)) {
-			$window.bind("pageshow", function(event) {
+			$window.on("pageshow", function(event) {
 				if (event.originalEvent && event.originalEvent.persisted) {
 					elements.each(function() {
 						$(this).trigger("appear");

--- a/js/widgets/widget-print.js
+++ b/js/widgets/widget-print.js
@@ -16,8 +16,8 @@
 
 		init : function(c) {
 			c.$table
-				.unbind(printTable.event)
-				.bind(printTable.event, function() {
+				.off(printTable.event)
+				.on(printTable.event, function() {
 					// explicitly use table.config.widgetOptions because we want
 					// the most up-to-date values; not the 'wo' from initialization
 					printTable.process(c, c.widgetOptions);

--- a/js/widgets/widget-resizable.js
+++ b/js/widgets/widget-resizable.js
@@ -99,7 +99,7 @@
 							'unselectable' : 'on'
 						})
 						.data( 'header', $header )
-						.bind( 'selectstart', false );
+						.on( 'selectstart', false );
 				}
 			}
 			ts.resizable.bindings( c, wo );
@@ -191,17 +191,17 @@
 			if ( toggle ) {
 				$( 'body' )
 					.attr( 'unselectable', 'on' )
-					.bind( 'selectstart' + namespace, false );
+					.on( 'selectstart' + namespace, false );
 			} else {
 				$( 'body' )
 					.removeAttr( 'unselectable' )
-					.unbind( 'selectstart' + namespace );
+					.off( 'selectstart' + namespace );
 			}
 		},
 
 		bindings : function( c, wo ) {
 			var namespace = c.namespace + 'tsresize';
-			wo.$resizable_container.children().bind( 'mousedown', function( event ) {
+			wo.$resizable_container.children().on( 'mousedown', function( event ) {
 				// save header cell and mouse position
 				var column,
 					vars = wo.resizable_vars,
@@ -227,7 +227,7 @@
 			});
 
 			$( document )
-				.bind( 'mousemove' + namespace, function( event ) {
+				.on( 'mousemove' + namespace, function( event ) {
 					var vars = wo.resizable_vars;
 					// ignore mousemove if no mousedown
 					if ( !vars.disabled || vars.mouseXPosition === 0 || !vars.$target ) { return; }
@@ -240,7 +240,7 @@
 						ts.resizable.mouseMove( c, wo, event );
 					}
 				})
-				.bind( 'mouseup' + namespace, function() {
+				.on( 'mouseup' + namespace, function() {
 					if (!wo.resizable_vars.disabled) { return; }
 					ts.resizable.toggleTextSelection( c, wo, false );
 					ts.resizable.stopResize( c, wo );
@@ -248,18 +248,18 @@
 				});
 
 			// resizeEnd event triggered by scroller widget
-			$( window ).bind( 'resize' + namespace + ' resizeEnd' + namespace, function() {
+			$( window ).on( 'resize' + namespace + ' resizeEnd' + namespace, function() {
 				ts.resizable.setHandlePosition( c, wo );
 			});
 
 			// right click to reset columns to default widths
 			c.$table
-				.bind( 'columnUpdate' + namespace + ' pagerComplete' + namespace, function() {
+				.on( 'columnUpdate' + namespace + ' pagerComplete' + namespace, function() {
 					ts.resizable.setHandlePosition( c, wo );
 				})
 				.find( 'thead:first' )
 				.add( $( c.namespace + '_extra_table' ).find( 'thead:first' ) )
-				.bind( 'contextmenu' + namespace, function() {
+				.on( 'contextmenu' + namespace, function() {
 					// $.isEmptyObject() needs jQuery 1.4+; allow right click if already reset
 					var allowClick = wo.resizable_vars.storedSizes.length === 0;
 					ts.resizableReset( c.table );
@@ -347,12 +347,12 @@
 				c.$table.add( $( c.namespace + '_extra_table' ) )
 					.removeClass('hasResizable')
 					.children( 'thead' )
-					.unbind( 'contextmenu' + namespace );
+					.off( 'contextmenu' + namespace );
 
 				wo.$resizable_container.remove();
 				ts.resizable.toggleTextSelection( c, wo, false );
 				ts.resizableReset( table, refreshing );
-				$( document ).unbind( 'mousemove' + namespace + ' mouseup' + namespace );
+				$( document ).off( 'mousemove' + namespace + ' mouseup' + namespace );
 			}
 		}
 	});

--- a/js/widgets/widget-saveSort.js
+++ b/js/widgets/widget-saveSort.js
@@ -46,7 +46,7 @@
 					if (c.debug) {
 						console.log('saveSort: Last sort loaded: "' + sortList + '"' + ts.benchmark(time));
 					}
-					$table.bind('saveSortReset', function(event) {
+					$table.on('saveSortReset', function(event) {
 						event.stopPropagation();
 						ts.storage( table, 'tablesorter-savesort', '' );
 					});

--- a/js/widgets/widget-sortTbodies.js
+++ b/js/widgets/widget-sortTbodies.js
@@ -30,11 +30,11 @@
 			}
 
 			c.$table
-				.unbind( 'sortBegin updateComplete '.split( ' ' ).join( namespace + ' ' ) )
-				.bind( 'sortBegin' + namespace, function() {
+				.off( 'sortBegin updateComplete '.split( ' ' ).join( namespace + ' ' ) )
+				.on( 'sortBegin' + namespace, function() {
 					ts.sortTbodies.sorter( c );
 				})
-				.bind( 'updateComplete' + namespace, function() {
+				.on( 'updateComplete' + namespace, function() {
 					// find parsers for each column
 					ts.sortTbodies.setTbodies( c, wo );
 					ts.updateCache( c, null, c.$tbodies );
@@ -219,7 +219,7 @@
 			ts.sortTbodies.init( c, wo );
 		},
 		remove : function( table, c, wo, refreshing ) {
-			c.$table.unbind( 'sortBegin updateComplete '.split( ' ' ).join( c.namespace + 'sortTbody ' ) );
+			c.$table.off( 'sortBegin updateComplete '.split( ' ' ).join( c.namespace + 'sortTbody ' ) );
 			c.serverSideSorting = wo.sortTbody_original_serverSideSorting;
 			c.cssInfoBlock = wo.sortTbody_original_cssInfoBlock;
 		}

--- a/js/widgets/widget-staticRow.js
+++ b/js/widgets/widget-staticRow.js
@@ -59,8 +59,8 @@
 			addIndexes(table);
 			// refresh static rows after updates
 			c.$table
-				.unbind( ('updateComplete.tsstaticrows ' + wo.staticRow_event).replace(/\s+/g, ' ') )
-				.bind('updateComplete.tsstaticrows ' + wo.staticRow_event, function(){
+				.off( ('updateComplete.tsstaticrows ' + wo.staticRow_event).replace(/\s+/g, ' ') )
+				.on('updateComplete.tsstaticrows ' + wo.staticRow_event, function(){
 					addIndexes(table);
 					ts.applyWidget( table );
 				});
@@ -113,7 +113,7 @@
 		},
 
 		remove : function(table, c, wo){
-			c.$table.unbind( ('updateComplete.tsstaticrows ' + wo.staticRow_event).replace(/\s+/g, ' ') );
+			c.$table.off( ('updateComplete.tsstaticrows ' + wo.staticRow_event).replace(/\s+/g, ' ') );
 		}
 
 	});

--- a/js/widgets/widget-stickyHeaders.js
+++ b/js/widgets/widget-stickyHeaders.js
@@ -210,7 +210,7 @@
 			// update sticky header class names to match real header after sorting
 			$table
 				.addClass('hasStickyHeaders')
-				.bind('pagerComplete' + namespace, function() {
+				.on('pagerComplete' + namespace, function() {
 					resizeHeader();
 				});
 
@@ -235,13 +235,13 @@
 
 			// make it sticky!
 			$xScroll.add($yScroll)
-				.unbind( ('scroll resize '.split(' ').join( namespace )).replace(/\s+/g, ' ') )
-				.bind('scroll resize '.split(' ').join( namespace ), function( event ) {
+				.off( ('scroll resize '.split(' ').join( namespace )).replace(/\s+/g, ' ') )
+				.on('scroll resize '.split(' ').join( namespace ), function( event ) {
 					scrollSticky( event.type === 'resize' );
 				});
 			c.$table
-				.unbind('stickyHeadersUpdate' + namespace)
-				.bind('stickyHeadersUpdate' + namespace, function(){
+				.off('stickyHeadersUpdate' + namespace)
+				.on('stickyHeadersUpdate' + namespace, function(){
 					scrollSticky( true );
 				});
 
@@ -252,7 +252,7 @@
 			// look for filter widget
 			if ($table.hasClass('hasFilters') && wo.filter_columnFilters) {
 				// scroll table into view after filtering, if sticky header is active - #482
-				$table.bind('filterEnd' + namespace, function() {
+				$table.on('filterEnd' + namespace, function() {
 					// $(':focus') needs jQuery 1.6+
 					var $td = $(document.activeElement).closest('td'),
 						column = $td.parent().children().index($td);
@@ -275,7 +275,7 @@
 
 			// resize table (Firefox)
 			if (wo.stickyHeaders_addResizeEvent) {
-				$table.bind('resize' + c.namespace + 'stickyheaders', function() {
+				$table.on('resize' + c.namespace + 'stickyheaders', function() {
 					resizeHeader();
 				});
 			}
@@ -287,14 +287,14 @@
 			var namespace = c.namespace + 'stickyheaders ';
 			c.$table
 				.removeClass('hasStickyHeaders')
-				.unbind( ('pagerComplete resize filterEnd stickyHeadersUpdate '.split(' ').join(namespace)).replace(/\s+/g, ' ') )
+				.off( ('pagerComplete resize filterEnd stickyHeadersUpdate '.split(' ').join(namespace)).replace(/\s+/g, ' ') )
 				.next('.' + ts.css.stickyWrap).remove();
 			if (wo.$sticky && wo.$sticky.length) { wo.$sticky.remove(); } // remove cloned table
 			$(window)
 				.add(wo.stickyHeaders_xScroll)
 				.add(wo.stickyHeaders_yScroll)
 				.add(wo.stickyHeaders_attachTo)
-				.unbind( ('scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') );
+				.off( ('scroll resize '.split(' ').join(namespace)).replace(/\s+/g, ' ') );
 			ts.addHeaderResizeEvent(table, true);
 		}
 	});

--- a/js/widgets/widget-uitheme.js
+++ b/js/widgets/widget-uitheme.js
@@ -103,8 +103,8 @@
 					.removeClass( (hasOldTheme ? [ oldtheme.header, oldtheme.hover, oldremove ].join(' ') : '') || '' )
 					.addClass(themes.header)
 					.not('.sorter-false')
-					.unbind('mouseenter.tsuitheme mouseleave.tsuitheme')
-					.bind('mouseenter.tsuitheme mouseleave.tsuitheme', function(event) {
+					.off('mouseenter.tsuitheme mouseleave.tsuitheme')
+					.on('mouseenter.tsuitheme mouseleave.tsuitheme', function(event) {
 						// toggleClass with switch added in jQuery 1.3
 						$(this)[ event.type === 'mouseenter' ? 'addClass' : 'removeClass' ](themes.hover || '');
 					});
@@ -184,7 +184,7 @@
 			if (refreshing) { return; }
 			$table.find(ts.css.header).removeClass(themes.header);
 			$headers
-				.unbind('mouseenter.tsuitheme mouseleave.tsuitheme') // remove hover
+				.off('mouseenter.tsuitheme mouseleave.tsuitheme') // remove hover
 				.removeClass(themes.hover + ' ' + remove + ' ' + themes.active)
 				.filter('.' + ts.css.filterRow)
 				.removeClass(themes.filterRow);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "docs": "https://mottie.github.io/tablesorter/docs/index.html",
   "demo": "https://github.com/Mottie/tablesorter/wiki",
   "dependencies": {
-    "jquery": ">=1.2.6"
+    "jquery": ">=1.7.0"
   },
   "keywords": [
     "table",


### PR DESCRIPTION
Addressing #1292 : as of jQuery 3, `bind` and `unbind` are deprecated in favour of `on` and `off` respectively. This patch addresses that deprecation. I haven't touched the manual namespacing, though it would be prudent to clean that up too, on standardising on `on`/`off`

This does require updating the jQuery dependence from 1.2.6 to 1.7.0.