### PR TITLE
Update widget-grouping.js

### DIFF
--- a/js/widgets/widget-grouping.js
+++ b/js/widgets/widget-grouping.js
@@ -234,7 +234,8 @@
 				if ( $.isFunction( wo.group_formatter ) ) {
 					data.currentGroup = wo.group_formatter( ( data.group || '' ).toString(), data.column, c.table, c, wo, data ) || data.group;
 				}
-				data.$row.before( tsg.groupHeaderHTML( c, wo, data ) );
+				//add first() for groping with childRows
+				data.$row.first().before( tsg.groupHeaderHTML( c, wo, data ) );
 				if ( wo.group_saveGroups && !data.savedGroup && wo.group_collapsed && wo.group_collapsible ) {
 					// all groups start collapsed; data.groupIndex is 1 more than the expected index.
 					wo.group_collapsedGroups[ wo.group_collapsedGroup ].push( data.currentGroup + data.groupIndex );


### PR DESCRIPTION
//add first() for groping with childRows
                data.$row.first().before( tsg.groupHeaderHTML( c, wo, data ) );

If a group with child rows (tablesorter-childRow), then inserted two headers once- for main row and for child. Add the first() function before before() operation for solve this problem.
