### PR TITLE
Tbodysort widget enhancement.

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -85,7 +85,7 @@
 			cssAsc           : '',
 			cssDesc          : '',
 			cssNone          : '',
-			cssHeader        : 'testHead',
+			cssHeader        : '',
 			cssHeaderRow     : '',
 			cssProcessing    : '', // processing icon applied to header during sort/filter
 

--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -85,7 +85,7 @@
 			cssAsc           : '',
 			cssDesc          : '',
 			cssNone          : '',
-			cssHeader        : '',
+			cssHeader        : 'testHead',
 			cssHeaderRow     : '',
 			cssProcessing    : '', // processing icon applied to header during sort/filter
 

--- a/js/widgets/widget-sortTbodies.js
+++ b/js/widgets/widget-sortTbodies.js
@@ -43,10 +43,10 @@
 				.bind('sortEnd', function() {
 					// Moves the head row back to the top of the tbody
 					var lockHead = wo.sortTbody_lockHead;
-					var headClass = '.'+c.cssHeader;
+					var primaryRow = wo.sortTbody_primaryRow;
 
-					if ( lockHead ) {
-						c.$table.find( headClass ).each( function(){
+					if ( primaryRow ) {
+						c.$table.find( primaryRow ).each( function(){
 							$( this ).parents( 'tbody' ).prepend( this );
 						});
 					}

--- a/js/widgets/widget-sortTbodies.js
+++ b/js/widgets/widget-sortTbodies.js
@@ -1,6 +1,7 @@
-/*! tablesorter tbody sorting widget (BETA) - 11/22/2015 (v2.24.6)
+/*! tablesorter tbody sorting widget (BETA) - 11/07/2016 (v2.24.7)
  * Requires tablesorter v2.22.2+ and jQuery 1.4+
  * by Rob Garrison
+ * Contributors: Chris Rogers
  */
 /*jshint browser:true, jquery:true, unused:false */
 /*global jQuery: false */
@@ -38,6 +39,17 @@
 					// find parsers for each column
 					ts.sortTbodies.setTbodies( c, wo );
 					ts.updateCache( c, null, c.$tbodies );
+				})
+				.bind('sortEnd', function() {
+					// Moves the head row back to the top of the tbody
+					var lockHead = wo.sortTbody_lockHead;
+					var headClass = '.'+c.cssHeader;
+
+					if ( lockHead ) {
+						c.$table.find( headClass ).each( function(){
+							$( this ).parents( 'tbody' ).prepend( this );
+						});
+					}
 				});
 
 			// detect parsers - in case the table contains only info-only tbodies

--- a/js/widgets/widget-sortTbodies.js
+++ b/js/widgets/widget-sortTbodies.js
@@ -42,10 +42,9 @@
 				})
 				.bind('sortEnd', function() {
 					// Moves the head row back to the top of the tbody
-					var lockHead = wo.sortTbody_lockHead;
 					var primaryRow = wo.sortTbody_primaryRow;
 
-					if ( primaryRow ) {
+					if ( wo.sortTbody_lockHead && primaryRow ) {
 						c.$table.find( primaryRow ).each( function(){
 							$( this ).parents( 'tbody' ).prepend( this );
 						});


### PR DESCRIPTION
I needed to sort my `<tbody>`'s and their child rows, but I wanted to keep the header rows at the top of the parent `<tbody>`, so I added a little extra code to accomplish this since I didn't know of any other widget that could do it. 

I haven't been able to unit test my code since I have a tight schedule at the moment, however its a very small snippet and not much could go wrong. It's working and I'm using it on my production server too, so should any issue arise, I'll be back to fix it.

Short description of what this new widget option `sortTbody_lockHead` does:
After the table has finished sorting, the table rows with the same class tag value specified in `cssHeader` inside the config `js/jquery.tablesorter.js` is moved to the top of it's parent `<tbody>` .