### PR TITLE
Fixed an issue that occurred when you try to download table data as CSV

### DIFF
--- a/js/widgets/widget-output.js
+++ b/js/widgets/widget-output.js
@@ -85,7 +85,7 @@
 						colspanLen = parseInt( $cell.attr('colspan'), 10) - 1;
 						// allow data-attribute to be an empty string
 						txt = output.formatData( c, wo, $cell, isHeader );
-						for (col = 1; col <= colspanLen; col++) {
+						for (col = 0; col < colspanLen; col++) {
 							// if we're processing the header & making JSON, the header names need to be unique
 							if ($cell.filter('[rowspan]').length) {
 								rowspanLen = parseInt( $cell.attr('rowspan'), 10);


### PR DESCRIPTION
Fixed an issue that occurred when you try to download table data as CSV with multiple headers and Colspan greater than 3. It caused column header alignment problem when I export out.

Here is the table which was causing problem.
![workspaces](https://cloud.githubusercontent.com/assets/1697617/24480806/32a496ae-149b-11e7-8737-aab5bc3b7995.png)
