### PR TITLE
Height Issues For Certain Browsers

### DIFF
--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -328,7 +328,11 @@
 				if (p.fixedHeight && !p.isDisabled) {
 					h = $.data(table, 'pagerSavedHeight');
 					if (h) {
-						d = h - $b.height();
+						var bs = 0;
+						if($(table).css('border-spacing').split(" ").length>0){
+							bs = $(table).css('border-spacing').split(" ")[0].replace(/[^-\d\.]/g, '');
+						}
+						d = h - $b.height()+(bs*p.size)-bs;
 						if ( d > 5 && $.data(table, 'pagerLastSize') === p.size &&
 						$b.children('tr:visible').length < (p.size === 'all' ? p.totalRows : p.size) ) {
 							$b.append('<tr class="pagerSavedHeightSpacer ' + c.selectorRemove.slice(1) + '" style="height:' + d + 'px;"></tr>');

--- a/addons/pager/jquery.tablesorter.pager.js
+++ b/addons/pager/jquery.tablesorter.pager.js
@@ -329,8 +329,8 @@
 					h = $.data(table, 'pagerSavedHeight');
 					if (h) {
 						var bs = 0;
-						if($(table).css('border-spacing').split(" ").length>0){
-							bs = $(table).css('border-spacing').split(" ")[0].replace(/[^-\d\.]/g, '');
+						if($(table).css('border-spacing').split(" ").length>1){
+							bs = $(table).css('border-spacing').split(" ")[1].replace(/[^-\d\.]/g, '');
 						}
 						d = h - $b.height()+(bs*p.size)-bs;
 						if ( d > 5 && $.data(table, 'pagerLastSize') === p.size &&


### PR DESCRIPTION
I added this in my own personal implementation to fix an issue where the pagerSavedHeightSpacer's height was being calculated incorrectly due to it only taking into account the height of tbody and the height of the trs. Another thing in a table that can add height is the User Agent Style Sheet of the browser adding a border-spacing property (which is usually 2px). This property has been accounted for in the following code. If that property does not exist, it will simply do the same calculation it always has.