### PR TITLE
Use calculated index instead of DOM index

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -548,7 +548,7 @@
 				timer = new Date();
 			}
 			// children tr in tfoot - see issue #196 & #547
-			// don't pass table.config to CColumnIndex here - widgets (math) pass it to "quickly" index tbody cells
+			// don't pass table.config to computeColumnIndex here - widgets (math) pass it to "quickly" index tbody cells
 			c.columns = ts.computeColumnIndex( c.$table.children( 'thead, tfoot' ).children( 'tr' ) );
 			// add icon if cssIcon option exists
 			icon = c.cssIcon ?

--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -548,7 +548,7 @@
 				timer = new Date();
 			}
 			// children tr in tfoot - see issue #196 & #547
-			// don't pass table.config to computeColumnIndex here - widgets (math) pass it to "quickly" index tbody cells
+			// don't pass table.config to CColumnIndex here - widgets (math) pass it to "quickly" index tbody cells
 			c.columns = ts.computeColumnIndex( c.$table.children( 'thead, tfoot' ).children( 'tr' ) );
 			// add icon if cssIcon option exists
 			icon = c.cssIcon ?
@@ -2240,7 +2240,7 @@
 				cells = $rows[ i ].cells;
 				for ( j = 0; j < cells.length; j++ ) {
 					cell = cells[ j ];
-					rowIndex = cell.parentNode.rowIndex;
+					rowIndex = i;
 					rowSpan = cell.rowSpan || 1;
 					colSpan = cell.colSpan || 1;
 					if ( typeof matrix[ rowIndex ] === 'undefined' ) {


### PR DESCRIPTION
There seems to be a scenario when there are multiple `thead` entries in a table where some versions of Firefox (around 47) return -1 for `cell.parentNode.rowIndex`, which winds up with the whole top part being laid out wrongly.

However, I looked this over and did not see any reason why not to use the calculated `i` for the row index instead.