### PR TITLE
PR to fix issue #1297 - Save position to fix scroller_upAfterSort=false 

### DIFF
--- a/js/widgets/widget-scroller.js
+++ b/js/widgets/widget-scroller.js
@@ -273,6 +273,10 @@
 			$tableWrap
 				.off( 'scroll' + namespace )
 				.on( 'scroll' + namespace, function() {
+					//Save position
+					wo.scroller_saved[0] = $tableWrap.scrollLeft()
+					wo.scroller_saved[1] = $tableWrap.scrollTop()
+				
 					if ( wo.scroller_jumpToHeader ) {
 						var pos = $win.scrollTop() - $hdr.offset().top;
 						if ( $( this ).scrollTop() !== 0 && pos < tbHt && pos > 0 ) {

--- a/js/widgets/widget-scroller.js
+++ b/js/widgets/widget-scroller.js
@@ -274,8 +274,8 @@
 				.off( 'scroll' + namespace )
 				.on( 'scroll' + namespace, function() {
 					//Save position
-					wo.scroller_saved[0] = $tableWrap.scrollLeft()
-					wo.scroller_saved[1] = $tableWrap.scrollTop()
+					wo.scroller_saved[0] = $tableWrap.scrollLeft();
+					wo.scroller_saved[1] = $tableWrap.scrollTop();
 				
 					if ( wo.scroller_jumpToHeader ) {
 						var pos = $win.scrollTop() - $hdr.offset().top;


### PR DESCRIPTION
This change saves to current position on scroll to be able to restore the position, e.g. after sort or when elements (like checkboxes) are changed.