### PR TITLE
Prevent sort2Hash from adding extraneous entries to browser history

### DIFF
--- a/js/widgets/widget-sort2Hash.js
+++ b/js/widgets/widget-sort2Hash.js
@@ -225,8 +225,19 @@
 				hash = s2h.cleanHash( c, wo, component, hash );
 				str += value;
 			});
-			// add updated hash
-			window.location.hash = ( ( window.location.hash || '' ).replace( '#', '' ).length ? hash : wo.sort2Hash_hash ) + str;
+
+			// Combine new hash with any existing hashes
+			var hashChar = c.widgetOptions.sort2Hash_hash;
+			var newHash = ( ( window.location.hash || '' ).replace( hashChar, '' ).length ? hash : wo.sort2Hash_hash ) + str;
+			var baseUrl = window.location.href.split(hashChar)[0];
+			// Ensure that there is a leading hash character
+			var firstChar = newHash[0];
+			if (firstChar != hashChar) {
+					newHash = hashChar + newHash;
+			}
+
+			// Update URL in browser
+			window.location.replace(baseUrl + newHash);
 		}
 	};
 


### PR DESCRIPTION
Addresses https://github.com/userfrosting/UserFrosting/issues/712 by using `window.location.replace` to update the browser URL only, rather than `window.location.hash`, which modifies the browser history.

Before you merge, a few things:

- I haven't written any automated tests for this, as I'm not really familiar with qunit.  It seems to work fine in UserFrosting, including scenarios with multiple tablesorters on the same page;
- It's possible that these additional history entries might be considered a "feature" for some users; in that case we should probably make this a configurable option for the `sort2Hash` widget;
- I don't know if this will cause adverse reactions with other widgets/features that may rely on the hashed URL being added to the browser history.