### PR TITLE
Feature Request to Issue filter_searchTrigger #1522

### DIFF
--- a/js/widgets/widget-filter.js
+++ b/js/widgets/widget-filter.js
@@ -906,7 +906,7 @@
 							}
 						}
 							// change & input events must be ignored if liveSearch !== true
-					} else if ( eventType === 'change' || eventType === 'input' ) &&
+					} else if ( ( eventType === 'change' || eventType === 'input' ) &&
 							// prevent search if liveSearch is a number
 							( liveSearch === true || liveSearch !== true && event.target.nodeName !== 'INPUT' ) &&
 							// don't allow 'change' or 'input' event to process if the input value

--- a/js/widgets/widget-filter.js
+++ b/js/widgets/widget-filter.js
@@ -467,7 +467,7 @@
 						for (var t in searchTrigger){
 							// events
 							var stType = typeof searchTrigger[t];
-							if(stType === "string" && eventType === searchTrigger[t]){
+							if(stType === "string" && event.type === searchTrigger[t]){
 								triggerSearch = true;
 								break;
 							}


### PR DESCRIPTION
Hey Mottie,

i created a pull request for the enhancement in Issue #1522.

Maybe you have some time to review and test the feature?
I created a fiddle:  http://jsfiddle.net/856bzzeL/1568/ 

Option description:
to enable the feature the option filter_liveSearch must set to false

Possible Values:
bool = default
Number = keycode
 String = events ( search, blur )
Objects  = { keyCode : Number, alt: bool, ctrl: bool, shift: bool }

Examples:
 filter_searchTrigger : false     -> same als ['search', 'blur', 13]
 filter_searchTrigger : [13]   -> Enter
 filter_searchTrigger :[ 13, 9]  -> Enter and tab - key
 filter_searchTrigger : ['blur']
 filter_searchTrigger : [{keyCode: 13, ctrl:true}] -> ctrl + Enter