### PR TITLE
Updating the composer.json to fix syntax issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,10 @@
   },
   "authors": [{
     "name": "Christian Bach",
-    "url": "http://tablesorter.com/"
+    "homepage": "http://tablesorter.com/"
   },{
     "name": "Rob Garrison",
-    "url": "https://github.com/Mottie",
+    "homepage": "https://github.com/Mottie",
     "email": "wowmotty@gmail.com"
   }],
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     "components/jquery": ">=1.2.6"
   },
   "authors": [{
-    "name": "Christian Bach",
-    "homepage": "http://tablesorter.com/"
+    "name": "Christian Bach"
   },{
     "name": "Rob Garrison",
     "homepage": "https://github.com/Mottie",


### PR DESCRIPTION
The author object within [composer.json](/composer.json) does not support the `uri` key. For author URLs, the `homepage` key should be used. 
Reference: [https://getcomposer.org/doc/04-schema.md#authors](https://getcomposer.org/doc/04-schema.md#authors)