### PR TITLE
Performance boost

### DIFF
--- a/js/jquery.tablesorter.combined.js
+++ b/js/jquery.tablesorter.combined.js
@@ -4505,6 +4505,14 @@
 					// look for multiple columns '1-3,4-6,8'
 					tsf.multipleColumns( c, wo.filter_$anyMatch ) :
 					[];
+
+			// in case select filter option has a different value vs text 'a - z|A through Z'
+			ffxn = wo.filter_columnFilters ?
+				c.$filters.add( wo.filter_$externalFilters )
+					.filter( '[data-column="' + columnIndex + '"]' )
+					.find( 'select option:selected' )
+					.attr( 'data-function-name' ) || '' : '';
+
 			data.$cells = data.$row.children();
 			data.matchedOn = null;
 			if ( data.anyMatchFlag && columnIndex.length > 1 || ( data.anyMatchFilter && !hasAnyMatchInput ) ) {
@@ -4571,12 +4579,6 @@
 
 					result = showRow; // if showRow is true, show that row
 
-					// in case select filter option has a different value vs text 'a - z|A through Z'
-					ffxn = wo.filter_columnFilters ?
-						c.$filters.add( wo.filter_$externalFilters )
-							.filter( '[data-column="' + columnIndex + '"]' )
-							.find( 'select option:selected' )
-							.attr( 'data-function-name' ) || '' : '';
 					// replace accents - see #357
 					if ( c.sortLocaleCompare ) {
 						data.filter = ts.replaceAccents( data.filter );

--- a/js/jquery.tablesorter.widgets.js
+++ b/js/jquery.tablesorter.widgets.js
@@ -1583,13 +1583,13 @@
 				showRow = true,
 				hasAnyMatchInput = wo.filter_$anyMatch && wo.filter_$anyMatch.length,
 
-				// if wo.filter_$anyMatch data-column attribute is changed dynamically
-				// we don't want to do an "anyMatch" search on one column using data
-				// for the entire row - see #998
-				columnIndex = wo.filter_$anyMatch && wo.filter_$anyMatch.length ?
-					// look for multiple columns '1-3,4-6,8'
-					tsf.multipleColumns( c, wo.filter_$anyMatch ) :
-					[];
+			// if wo.filter_$anyMatch data-column attribute is changed dynamically
+			// we don't want to do an "anyMatch" search on one column using data
+			// for the entire row - see #998
+			columnIndex = wo.filter_$anyMatch && wo.filter_$anyMatch.length ?
+				// look for multiple columns '1-3,4-6,8'
+				tsf.multipleColumns( c, wo.filter_$anyMatch ) :
+				[];
 			data.$cells = data.$row.children();
 			data.matchedOn = null;
 			if ( data.anyMatchFlag && columnIndex.length > 1 || ( data.anyMatchFilter && !hasAnyMatchInput ) ) {


### PR DESCRIPTION
there was an unnecessary find which was in a loop of each column for each row,

this caused to execute 32.000 times if you have 4.000 rows and 8 columns, this was unneeded and heavy.

in above mentioned values you could wait for 5 minutes until a select filter was executed, after patch this changed to approx 2 seconds