### PR TITLE
Avoid getting rows from nested tables

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -1353,7 +1353,7 @@
 			cell = $cell[ 0 ]; // in case cell is a jQuery object
 			// tbody may not exist if update is initialized while tbody is removed for processing
 			if ( $tbodies.length && tbodyIndex >= 0 ) {
-				row = $tbodies.eq( tbodyIndex ).find( 'tr' ).not( '.' + c.cssChildRow ).index( $row );
+				row = $tbodies.eq( tbodyIndex ).children( 'tr' ).not( '.' + c.cssChildRow ).index( $row );
 				cache = tbcache.normalized[ row ];
 				len = $row[ 0 ].cells.length;
 				if ( len !== c.columns ) {


### PR DESCRIPTION
I am working with nested tables and I noticed that the row index was wrong after the first row...

This happens because `.find` gets all descendant `tr` including the ones in nested tables, causing the row index to go bananas.

So my solution was to use `.children` instead, because it only includes `tr` from current `tbody`.