### PR TITLE
Add role for accessibility

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -638,7 +638,7 @@
 			}
 			c.$table.find( c.selectorHeaders ).attr({
 				scope: 'col',
-				role : 'columnheader'
+				role : 'switch columnheader'
 			});
 			// enable/disable sorting
 			ts.updateHeader( c );


### PR DESCRIPTION
Since the columnheader also functions as a switch it would make sense to add this as a role for screen readers as well.