### PR TITLE
Addressing 'tarball data corrupted' error upon installing package from GitHub repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -44,6 +44,5 @@ CONTRIBUTING.md         export-ignore
 example.json            export-ignore
 Gruntfile.js            export-ignore
 index.html              export-ignore
-package.json            export-ignore
 tablesorter.jquery.json export-ignore
 test.html               export-ignore


### PR DESCRIPTION
When this GitHub repository is utilized as a dependency in another NPM package, such as the example shown below:

```json
"dependencies": {
    "tablesorter": "git+https://github.com/Mottie/tablesorter.git"
}
```

Executing the `npm install` command fails and triggers the following error:

```shell
npm WARN tarball tarball data for tablesorter@git+ssh://git@github.com/Mottie/tablesorter.git#028b50d2a80f86965938168c581d3fc8ed88c1b8 (null) seems to be corrupted. Trying again.
npm WARN tarball tarball data for tablesorter@git+ssh://git@github.com/Mottie/tablesorter.git#028b50d2a80f86965938168c581d3fc8ed88c1b8 (null) seems to be corrupted. Trying again.
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /home/k2/.npm/_cacache/tmp/git-clonejbk2Mx/package.json
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/home/k2/.npm/_cacache/tmp/git-clonejbk2Mx/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 
```

This PR fixes that.

Note: Tested with Node v18.14.2 and NPM v9.6.0