### PR TITLE
initialize headers to null

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -49,7 +49,7 @@
 			resort           : true,       // default setting to trigger a resort after an 'update', 'addRows', 'updateCell', etc has completed
 
 			// *** sort options
-			headers          : {},         // set sorter, string, empty, locked order, sortInitialOrder, filter, etc.
+			headers          : null,       // set sorter, string, empty, locked order, sortInitialOrder, filter, etc.
 			ignoreCase       : true,       // ignore case while sorting
 			sortForce        : null,       // column(s) first sorted; always applied
 			sortList         : [],         // Initial sort order; applied initially; updated when manually sorted


### PR DESCRIPTION
I was debugging a performance issue in a library that vendors tablesorter and came across this issue.

Almost all accesses to `c.headers` are through `ts.getColumnData` as best I can tell.

That function has an [early return](https://github.com/Mottie/tablesorter/blob/fb6b6aa7800d74134c8a8e9602a487d1226eeb8d/js/jquery.tablesorter.js#L2415) in case `c.headers` is null/undefined/etc because the function can't do anything useful in that case.

Well, the default of `headers` is `{}`, so the early-return doesn't get triggered. In my case, that caused [`$cells.find(...)`](https://github.com/Mottie/tablesorter/blob/fb6b6aa7800d74134c8a8e9602a487d1226eeb8d/js/jquery.tablesorter.js#L2424) to get hammered, drastically slowing down page load by 10-30s.

Here's a profile before:
![without-sortable](https://github.com/user-attachments/assets/73aa572e-5e6f-4954-9ff8-a5827ba1362e)

And here's one after:
![with-all-fixes](https://github.com/user-attachments/assets/27722e86-5931-43e3-9394-0dab53140bd7)

Of course, if any headers config was defined, this would still be very slow. I'm not sure if it's possible to constrain or optimize the `.find` call to help in that case.

But at least now the default config is significantly faster.

Another option would be to check `Object.keys(headers).length === 0`.